### PR TITLE
Reverting back the use of sonar cloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-addons:
-  sonarcloud:
-    token:
-      secure: "${SONAR_CLOUD_TOKEN}"
-
 script:
   - echo "Running tests..."
   - pytest --cov=stix_shifter --cov-report=xml
-  # - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "" ]; then sonar-scanner; fi # sonar scan on internal PRs
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_REPO_SLUG" == "ibm/stix-shifter" ]; then sonar-scanner; fi # sonar scan on non-PRs

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-sonar.sourceEncoding=UTF-8
-sonar.sources=stix_shifter
-sonar.organization=isc-uds
-sonar.projectKey=stix-shifter
-sonar.tests=tests
-sonar.host.url=https://sonarcloud.io
-sonar.python.coverage.reportPaths=/home/travis/build/IBM/stix-shifter/coverage.xml


### PR DESCRIPTION
It unnecessary to use sonar cloud without PR analysis. We are already using our ibm sonarqube for master branch analysis.
