### PR TITLE
Add delete query connection method to bundle connector 

### DIFF
--- a/stix_shifter/stix_transmission/src/modules/stix_bundle/stix_bundle_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/stix_bundle/stix_bundle_connector.py
@@ -98,3 +98,8 @@ class Connector(BaseConnector):
                 return_obj['data'] = []
 
         return return_obj
+
+    def delete_query_connection(self, search_id):
+        return_obj = dict()
+        return_obj['success'] = True
+        return return_obj


### PR DESCRIPTION
So it doesn't thrown an error if no results were returned