### PR TITLE
Updated Bigfix adapter with review comments

### DIFF
--- a/stix_shifter/stix_translation/src/modules/bigfix/json/to_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/bigfix/json/to_stix_map.json
@@ -7,7 +7,7 @@
         {
             "key": "directory.path",
             "object": "directory",
-            "transformer": "ToFilePath"
+            "transformer": "ToDirectoryPath"
         },
         {
             "key": "file.parent_directory_ref",

--- a/stix_shifter/stix_translation/src/modules/bigfix/json/to_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/bigfix/json/to_stix_map.json
@@ -6,7 +6,8 @@
     "file_path": [
         {
             "key": "directory.path",
-            "object": "directory"
+            "object": "directory",
+            "transformer": "ToFilePath"
         },
         {
             "key": "file.parent_directory_ref",
@@ -139,16 +140,6 @@
       {
         "key": "mac-addr.value",
         "object": "src_mac"
-      },
-      {
-        "key": "ipv4-addr.resolves_to_refs",
-        "object": "src_ip",
-        "references": "src_mac"
-      },
-      {
-        "key": "ipv6-addr.resolves_to_refs",
-        "object": "src_ip",
-        "references": "src_mac"
       }
     ]
 }

--- a/stix_shifter/stix_translation/src/utils/transformers.py
+++ b/stix_shifter/stix_translation/src/utils/transformers.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone, tzinfo, timedelta
 import base64
 import socket
 import re
+import os
 from urllib.parse import urlparse
 
 
@@ -116,7 +117,7 @@ class ToFilePath(ValueTransformer):
     @staticmethod
     def transform(obj):
         try:
-            return obj[0:len(obj) - len(re.split(r'[\\/]', obj)[-1])]
+            return os.path.dirname(obj)
         except ValueError:
             print("Cannot convert input to path string")
 

--- a/stix_shifter/stix_translation/src/utils/transformers.py
+++ b/stix_shifter/stix_translation/src/utils/transformers.py
@@ -117,9 +117,20 @@ class ToFilePath(ValueTransformer):
     @staticmethod
     def transform(obj):
         try:
-            return os.path.dirname(obj)
+            return obj[0:len(obj) - len(re.split(r'[\\/]', obj)[-1])]
         except ValueError:
             print("Cannot convert input to path string")
+
+
+class ToDirectoryPath(ValueTransformer):
+    """A value transformer for expected directory path"""
+
+    @staticmethod
+    def transform(obj):
+        try:
+            return os.path.dirname(obj)
+        except ValueError:
+            print("Cannot convert input to directory path string")
 
 
 class ToFileName(ValueTransformer):
@@ -224,4 +235,5 @@ def get_all_transformers():
             "ToLowercaseArray": ToLowercaseArray, "ToBase64": ToBase64, "ToFilePath": ToFilePath, "ToFileName": ToFileName,
             "StringToBool": StringToBool, "ToDomainName": ToDomainName, "TimestampToMilliseconds": TimestampToMilliseconds,
             "EpochSecondsToTimestamp": EpochSecondsToTimestamp, "ToIPv4": ToIPv4,
-            "DateTimeToUnixTimestamp": DateTimeToUnixTimestamp, "NaiveTimestampToUTC": TimestampToUTC}
+            "DateTimeToUnixTimestamp": DateTimeToUnixTimestamp, "NaiveTimestampToUTC": TimestampToUTC,
+            "ToDirectoryPath": ToDirectoryPath}

--- a/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_api_client.py
+++ b/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_api_client.py
@@ -12,21 +12,15 @@ class APIClient:
     def __init__(self, connection, configuration):
         self.endpoint_start = 'api/'
         auth = configuration.get('auth')
-        headers = dict()
-        headers['Authorization'] = b"Basic " + base64.b64encode(
+        self.headers = dict()
+        self.headers['Authorization'] = b"Basic " + base64.b64encode(
                 (auth['username'] + ':' + auth['password']).encode('ascii'))
-        self.client = RestApiClient(connection.get('host'),
-                                    connection.get('port'),
-                                    connection.get('cert', None),
-                                    headers,
-                                    cert_verify=connection.get('selfSignedCert', True),
-                                    mutual_auth=connection.get('use_securegateway', False),
-                                    sni=connection.get('sni', None)
-                                    )
+        self.connection = connection
+        self.configuration = configuration
 
     def ping_box(self):
         endpoint = self.endpoint_start + self.PING_ENDPOINT
-        return self.client.call_api(endpoint, 'GET')
+        return self.get_api_client().call_api(endpoint, 'GET')
 
     def create_search(self, query_expression):
         headers = dict()
@@ -34,7 +28,7 @@ class APIClient:
         endpoint = self.endpoint_start + self.QUERY_ENDPOINT
         data = query_expression
         data = data.encode('utf-8')
-        return self.client.call_api(endpoint, 'POST', headers, data=data)
+        return self.get_api_client().call_api(endpoint, 'POST', headers, data=data)
 
     def get_search_results(self, search_id, offset, length):
         headers = dict()
@@ -45,11 +39,21 @@ class APIClient:
         params['stats'] = '1'
         params['start'] = offset
         params['count'] = length
-        return self.client.call_api(endpoint, 'GET', headers, urldata=params)
+        return self.get_api_client().call_api(endpoint, 'GET', headers, urldata=params)
 
     def get_sync_query_results(self, relevance):
         headers = dict()
         endpoint = self.endpoint_start + self.SYNC_QUERY_ENDPOINT
         params = dict()
         params['relevance'] = relevance
-        return self.client.call_api(endpoint, 'GET', headers, urldata=params)
+        return self.get_api_client().call_api(endpoint, 'GET', headers, urldata=params)
+
+    def get_api_client(self):
+        api_client = RestApiClient(self.connection.get('host'),
+                                   self.connection.get('port'),
+                                   self.connection.get('cert', None),
+                                   self.headers, cert_verify=self.connection.get('selfSignedCert', True),
+                                   mutual_auth=self.connection.get('use_securegateway', False),
+                                   sni=self.connection.get('sni', None)
+                                   )
+        return api_client

--- a/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_results_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_results_connector.py
@@ -1,5 +1,6 @@
 from ..base.base_results_connector import BaseResultsConnector
 import json
+import time
 from .....utils.error_response import ErrorResponder
 import xmltodict
 
@@ -15,7 +16,7 @@ class BigFixResultsConnector(BaseResultsConnector):
     @staticmethod
     def get_success_status(data_dict):
         items = ErrorResponder.get_struct_item(data_dict, ['results', '+isFailure=False'])
-        return len(items) > 0
+        return len(items) >= 0
 
     def create_results_connection(self, search_id, offset, length):
         response_txt = None
@@ -126,12 +127,16 @@ class BigFixResultsConnector(BaseResultsConnector):
         :param formatted_obj: dict
         :return: dict
         """
-        attr_with_na_value_index_dict = {'local_address': (1, ('n/a',)), 'mac': (2, ('n/a',))
+        attr_with_na_value_index_dict = {'mac': (2, ('n/a',))
                                          }
         for key, value in attr_with_na_value_index_dict.items():
             if obj_list[value[0]].strip() not in value[1]:
-                formatted_obj[key] = obj_list[value[0]].strip()
+                if 'mac' in key:
+                    formatted_obj[key] = obj_list[value[0]].strip().replace('-', ':')
+                else:
+                    formatted_obj[key] = obj_list[value[0]].strip()
         formatted_obj['type'] = obj_list[0].strip()
+        formatted_obj['timestamp'] = int(time.time())
         formatted_obj['event_count'] = "1"
         return formatted_obj
 

--- a/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_status_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_status_connector.py
@@ -53,15 +53,12 @@ class BigFixStatusConnector(BaseStatusConnector):
         :return: dict
         """
         reporting_agents = int(response_dict.get('reportingAgents', '0'))
-        total_results = int(response_dict.get('totalResults', '0'))
         return_obj = self._get_progress_status(client_count, reporting_agents, return_obj)
         if client_count <= reporting_agents:
             return_obj['status'] = Status.COMPLETED.value
             return_obj['progress'] = 100
         else:
             if return_obj['progress'] > PROGRESS_THRESHOLD:
-                sleep_time = math.ceil((100 - return_obj['progress']) * 10 / 100)
-                time.sleep(sleep_time)
                 return_obj['status'] = Status.COMPLETED.value
                 return_obj['progress'] = 100
         return return_obj

--- a/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_status_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/bigfix/bigfix_status_connector.py
@@ -57,13 +57,13 @@ class BigFixStatusConnector(BaseStatusConnector):
         return_obj = self._get_progress_status(client_count, reporting_agents, return_obj)
         if client_count <= reporting_agents:
             return_obj['status'] = Status.COMPLETED.value
-            if total_results <= 0:
-                return_obj['status'] = Status.ERROR.value
+            return_obj['progress'] = 100
         else:
             if return_obj['progress'] > PROGRESS_THRESHOLD:
                 sleep_time = math.ceil((100 - return_obj['progress']) * 10 / 100)
                 time.sleep(sleep_time)
                 return_obj['status'] = Status.COMPLETED.value
+                return_obj['progress'] = 100
         return return_obj
 
     def status_api_response(self, search_id, client_count):

--- a/tests/stix_translation/test_car_json_to_stix.py
+++ b/tests/stix_translation/test_car_json_to_stix.py
@@ -171,7 +171,7 @@ class TestTransform(object):
         directory_obj = objects[directory_ref]
         assert(directory_obj.keys() == {'type', 'path'})
         assert(directory_obj['type'] == 'directory')
-        assert(directory_obj['path'] == 'C:\\mydir\\')
+        assert(directory_obj['path'] == 'C:\\mydir')
 
         parent_ref = process_obj['parent_ref']
         assert(parent_ref in objects), f"parent_ref with key {parent_ref} not found"
@@ -191,7 +191,7 @@ class TestTransform(object):
         parent_directory_obj = objects[parent_directory_ref]
         assert(parent_directory_obj.keys() == {'type', 'path'})
         assert(parent_directory_obj['type'] == 'directory')
-        assert(parent_directory_obj['path'] == 'C:\\Windows\\System32\\')
+        assert(parent_directory_obj['path'] == 'C:\\Windows\\System32')
 
         assert(objects.keys() == set(map(str, range(0, 6))))
 

--- a/tests/stix_translation/test_car_json_to_stix.py
+++ b/tests/stix_translation/test_car_json_to_stix.py
@@ -171,7 +171,7 @@ class TestTransform(object):
         directory_obj = objects[directory_ref]
         assert(directory_obj.keys() == {'type', 'path'})
         assert(directory_obj['type'] == 'directory')
-        assert(directory_obj['path'] == 'C:\\mydir')
+        assert(directory_obj['path'] == 'C:\\mydir\\')
 
         parent_ref = process_obj['parent_ref']
         assert(parent_ref in objects), f"parent_ref with key {parent_ref} not found"
@@ -191,7 +191,7 @@ class TestTransform(object):
         parent_directory_obj = objects[parent_directory_ref]
         assert(parent_directory_obj.keys() == {'type', 'path'})
         assert(parent_directory_obj['type'] == 'directory')
-        assert(parent_directory_obj['path'] == 'C:\\Windows\\System32')
+        assert(parent_directory_obj['path'] == 'C:\\Windows\\System32\\')
 
         assert(objects.keys() == set(map(str, range(0, 6))))
 

--- a/tests/stix_transmission/test_bigfix.py
+++ b/tests/stix_transmission/test_bigfix.py
@@ -283,7 +283,7 @@ class TestBigfixConnection(unittest.TestCase):
         assert 'status' in status_response
         assert status_response['status'] == "COMPLETED"
         assert 'progress' in status_response
-        assert status_response['progress'] == 75
+        assert status_response['progress'] == 100
 
     @staticmethod
     @patch('stix_shifter.stix_transmission.src.modules.bigfix.bigfix_api_client.APIClient.get_search_results')
@@ -304,7 +304,7 @@ class TestBigfixConnection(unittest.TestCase):
         assert 'success' in status_response
         assert status_response['success'] is True
         assert 'status' in status_response
-        assert status_response['status'] == "ERROR"
+        assert status_response['status'] == "COMPLETED"
         assert 'progress' in status_response
         assert status_response['progress'] == 100
 


### PR DESCRIPTION
1.	transformers.py
i.	Modified the existing code to return the parent directory_path using python os module.
2.	to_stix_map.json
i.	Added transformer "ToFilePath" to file:directory_path STIX_attribute to remove the filename from the path value.
ii.	Removed network-traffic attribute "resolved_to_ref" for mac-addr:value STIX attribute as BigFix doesnot provided network-traffic details while querying for mac-addr of local computer/machine.
3.	bigfix_api_client.py
i.	Created a new instance of RestApiClient as 2 subsequent API calls were throwing SSL error.
Verified the working of new code.
4.	bigfix_results_connector.py
i.	Modified the status parameter to return 'true' if the API call retuned a response code of 200 but no data is returned from BigFix server.
ii.	Modified the mac address query result method to fix --stix-validator issue
iii.	Modified progress percentage to 100% for “Completed” status
5.	bigfix_status_connector.py
i.	Removed a code that returned a status = 'ERROR' even if API call returned a response code of 200.
6.	test_bigfix.py
Modified unit test case code for above status query changes.
7.	test_car_json_to_stix.py
Modified unit test case for directory path value
