### PR TITLE
remove file.parent_directory_ref mapping since it was breaking on nul…

### DIFF
--- a/stix_shifter/stix_translation/src/modules/qradar/json/to_stix_map.json
+++ b/stix_shifter/stix_translation/src/modules/qradar/json/to_stix_map.json
@@ -163,11 +163,6 @@
     {
       "key": "directory.path",
       "object": "dir"
-    },
-    {
-      "key": "file.parent_directory_ref",
-      "object": "fl",
-      "references": "dir"
     }
   ],
   "base64_payload": {


### PR DESCRIPTION
…l values. need to go back and fix json-to-stix to account for this case