### PR TITLE
Fix bundle ping response and api call

### DIFF
--- a/stix_shifter/stix_transmission/src/modules/stix_bundle/stix_bundle_connector.py
+++ b/stix_shifter/stix_transmission/src/modules/stix_bundle/stix_bundle_connector.py
@@ -50,7 +50,7 @@ class Connector(BaseConnector):
         if response_code == 200 or response_code == 301:
             return_obj['success'] = True
         else:
-            ErrorResponder.fill_error(return_obj, ['message'])
+            ErrorResponder.fill_error(return_obj, response, ['message'])
         return return_obj
 
     def create_query_connection(self, query):


### PR DESCRIPTION
1. Ping didn't return correct status. Making a head call to bundle url to get the correct response
2. Empty Auth object was used to make api call which was failing on Github redirected address. It will also now avoid using auth(username/password) params if username/password is null.