### PR TITLE
Return supported attributes for specified module

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def __main__():
     translate_parser.add_argument(
         'module', choices=stix_translation.TRANSLATION_MODULES, help='The translation module to use')
     translate_parser.add_argument('translate_type', choices=[
-        stix_translation.RESULTS, stix_translation.QUERY, stix_translation.PARSE], help='The translation action to perform')
+        stix_translation.RESULTS, stix_translation.QUERY, stix_translation.PARSE, stix_translation.SUPPORTED_ATTRIBUTES], help='The translation action to perform')
     translate_parser.add_argument(
         'data_source', help='STIX identity object representing a datasource')
     translate_parser.add_argument(

--- a/stix_shifter/stix_translation/stix_translation.py
+++ b/stix_shifter/stix_translation/stix_translation.py
@@ -84,11 +84,7 @@ class StixTranslation:
                 if translate_type == QUERY:
                     if 'validate_pattern' in options and options['validate_pattern'] == "true":
                         self._validate_pattern(data)
-                    try:
-                        data_model = importlib.import_module("stix_shifter.stix_translation.src.modules." + module + ".data_mapping")
-                        data_model_mapper = data_model.DataMapper(options)
-                    except Exception as ex:
-                        data_model_mapper = self._cim_or_car_data_mapper(module, options)
+                    data_model_mapper = self._build_data_mapper(module, options)
                     antlr_parsing = generate_query(data)
                     if data_model_mapper:
                         # Remove unmapped STIX attributes from antlr parsing
@@ -115,14 +111,8 @@ class StixTranslation:
                     raise TranslationResultException()
             elif translate_type == SUPPORTED_ATTRIBUTES:
                 # Return mapped STIX attributes supported by the data source
-                try:
-                    data_model = importlib.import_module("stix_shifter.stix_translation.src.modules." + module + ".data_mapping")
-                    data_model_mapper = data_model.DataMapper(options)
-                except Exception as ex:
-                    data_model_mapper = self._cim_or_car_data_mapper(module, options)
-                
+                data_model_mapper = self._build_data_mapper(module, options)
                 mapped_attributes = data_model_mapper.map_data
-
                 return {'supported_attributes': mapped_attributes}
             else:
                 raise NotImplementedError('wrong parameter: ' + translate_type)
@@ -132,10 +122,15 @@ class StixTranslation:
             ErrorResponder.fill_error(response, message_struct={'exception': ex})
             return response
 
-    def _cim_or_car_data_mapper(self, module, options):
-        if options.get('data_mapper'):
-            return SHARED_DATA_MAPPERS[options.get('data_mapper')].mapper_class(options)
-        elif module in SHARED_DATA_MAPPERS:
-            return SHARED_DATA_MAPPERS[module].mapper_class(options)
-        else:
-            return None
+    def _build_data_mapper(self, module, options):
+        try:
+            data_model = importlib.import_module("stix_shifter.stix_translation.src.modules." + module + ".data_mapping")
+            return data_model.DataMapper(options)
+        except Exception as ex:
+            # Attempt to use the CIM or CAR mapper
+            if options.get('data_mapper'):
+                return SHARED_DATA_MAPPERS[options.get('data_mapper')].mapper_class(options)
+            elif module in SHARED_DATA_MAPPERS:
+                return SHARED_DATA_MAPPERS[module].mapper_class(options)
+            else:
+                return None


### PR DESCRIPTION
This basically adding this support will return the mapping stix objects from from_stix_map.json file on a translation call where the translation type is `supported_attributes`

This is a proposed solution where people would like to see what are the stix object they can specify in STIX pattern to native datasource query.