### PR TITLE
Ignore unexpected_params in param_validator.py

### DIFF
--- a/stix_shifter_utils/utils/param_validator.py
+++ b/stix_shifter_utils/utils/param_validator.py
@@ -69,7 +69,7 @@ def param_validator(module, input_configs):
         if isinstance(input_configs, dict):
             error_obj['unexpected_params'] = get_inner_keys(input_configs)
 
-    if error_obj:
+    if 'missing_params' in error_obj:
         raise ValueError(error_obj)
 
     return validated_params


### PR DESCRIPTION
In contrast to missing_params, unexpected_params should not raise an error (might only log a warning) 
In a scenario of cp4s connected to stix shifter in proxy host mode, there are few unexpected_params that can be ignore:
error occurred: {'unexpected_params': ['description', 'maxConcurrentSearches', 'name', 'requiresProxy', 'resultSizeLimit', 'timeoutLimit', 'use_securegateway', 'wizardType', 'host', 'port', 'type', 'users', 'connectionId', 'description', 'name', 'type']}
. All required parameters exists.