### PR TITLE
remove unneeded json.dumps

### DIFF
--- a/stix_shifter_utils/utils/proxy_host.py
+++ b/stix_shifter_utils/utils/proxy_host.py
@@ -23,9 +23,7 @@ class ProxyHost():
         return json.dumps(dsl['queries'])
 
     def translate_results(self, data_source_identity_object):
-        data_source_results = json.dumps(self.request_args["results"] )
-
-        print(data_source_results)
+        data_source_results = self.request_args["results"]
         translation_module = self.connection['type'].lower()
         translation = stix_translation.StixTranslation()
         dsl = translation.translate(translation_module, 'results', data_source_identity_object, data_source_results, self.connection)


### PR DESCRIPTION
remove unneeded json.dumps + print of the results argument in translate_results function. 
Otherwise it will not works when connecting as a proxy connector on cp4s.