### PR TITLE
Extra escaping for the value changing the AQL query value

### DIFF
--- a/stix_shifter_modules/qradar/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/qradar/stix_translation/query_constructor.py
@@ -85,7 +85,7 @@ class AqlQueryStringPatternTranslator:
     @staticmethod
     def _escape_value(value, comparator=None) -> str:
         if isinstance(value, str):
-            return '{}'.format(value.replace('\\', '\\\\').replace('\"', '\\"').replace('(', '\\(').replace(')', '\\)'))
+            return '{}'.format(value.replace('\"', '\\"').replace('(', '\\(').replace(')', '\\)'))
         else:
             return value
 


### PR DESCRIPTION
I am trying to execute the following query for cp4s for QRadar
`... WHERE qidname LIKE '%event\example%'`

STIX won’t let me do the query as `[(x-ibm-ariel:event_name LIKE '%event\example%')]` so it pass validation when adding extra \ to be `[(x-ibm-ariel:event_name LIKE '%event\\example%')]` but then, I don’t get any results since it query for `... WHERE Image LIKE '%event\\\\example%'` which does not match the single quote at the name '%event\example%'

I pin-point the place where the escaping is added.
