### PR TITLE
stix2-matcher library installation update

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -14,6 +14,7 @@
   - [Translate](#translate)
   - [Transmit](#transmit)
   - [Execute](#execute)
+  - [Debug](#Debug)
 - [Glossary](#glossary)
 - [Architecture Context](#architecture-context)
 - [Contributing](#contributing)
@@ -436,6 +437,12 @@ The `execute` command tests all steps of the translation-transmission flow:
 #### CLI Command
 
 `stix-shifter execute <TRANSMISSION MODULE NAME> <TRANSLATION MODULE NAME> '<STIX IDENTITY OBJECT>' '<CONNECTION OBJECT>' '<CONFIGURATION OBJECT>' '<STIX PATTERN>'`
+
+#### Debug
+
+You can add `--debug` option at the end of your CLI command to see more logs. 
+
+`stix-shifter execute <TRANSMISSION MODULE NAME> <TRANSLATION MODULE NAME> '<STIX IDENTITY OBJECT>' '<CONNECTION OBJECT>' '<CONFIGURATION OBJECT>' '<STIX PATTERN>' --debug` 
 
 #### OUTPUT:
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,11 @@ For more information about this project, see the [STIX-shifter Overview](https:/
 
 This stix-shifter has the following dependencies:
 
-- [stix2-patterns>=1.1.0](https://pypi.org/project/stix2-patterns/)
-- [stix2-validator>=0.5.0](https://pypi.org/project/stix2-validator/)
-- [stix2-matcher](https://github.com/oasis-open/cti-pattern-matcher): There is no python package publish in pypi for stix2-matcher. The bellow command can be used to install this package:
-  ```
-  pip install git+git://github.com/oasis-open/cti-pattern-matcher.git@b265862971eb63c04a8a054a2adb13860edf7846#egg=stix2-matcher
-  ```
-- [antlr4-python3-runtime>=4.7](https://pypi.org/project/antlr4-python3-runtime/)
-- [python-dateutil>=2.7.3](https://pypi.org/project/python-dateutil/)
+- [stix2-patterns==1.3.0](https://pypi.org/project/stix2-patterns/)
+- [stix2-validator==1.1.2](https://pypi.org/project/stix2-validator/)
+- [stix2-matcher==1.0.0](https://pypi.org/project/stix2-matcher/)
+- [antlr4-python3-runtime==4.8](https://pypi.org/project/antlr4-python3-runtime/)
+- [python-dateutil==2.8.1](https://pypi.org/project/python-dateutil/)
 
 Your development environment must use Python 3.6.x
 

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -1,4 +1,3 @@
-# git+git://github.com/oasis-open/cti-pattern-matcher.git@b265862971eb63c04a8a054a2adb13860edf7846#egg=stix2-matcher #uncomment when running locally
 adal==1.2.2
 antlr4-python3-runtime==4.8
 boto3==1.12.40
@@ -11,3 +10,4 @@ stix2-validator==1.1.2
 xmltodict==0.12.0
 jsonmerge==1.7.0
 colorlog==4.1.0
+stix2-matcher==1.0.0


### PR DESCRIPTION
Instead of installing it from github project, we now will install stix2-matcher from pypi and include that as project requirements. 