### PR TITLE
STIX Shifter that works with CP4S 1.3.0.1 as Proxy Host with QRadar

### DIFF
--- a/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix.py
+++ b/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix.py
@@ -29,4 +29,4 @@ class JSONToStix(BaseResultTranslator):
         except Exception as ex:
             raise TranslationResultException("Error when converting results to STIX: {}".format(ex))
         
-        return results
+        return json.dumps(results, indent=4, sort_keys=False)

--- a/stix_shifter_utils/utils/param_validator.py
+++ b/stix_shifter_utils/utils/param_validator.py
@@ -83,7 +83,7 @@ def param_validator(module, input_configs, start_point=None):
         if isinstance(input_configs, dict):
             error_obj['unexpected_params'] = input_configs
 
-    if error_obj:
+    if errors:
         raise ValueError(error_obj)
 
     return validated_params

--- a/stix_shifter_utils/utils/proxy_host.py
+++ b/stix_shifter_utils/utils/proxy_host.py
@@ -25,7 +25,7 @@ class ProxyHost():
         return json.dumps(dsl['queries'])
 
     def translate_results(self, data_source_identity_object):
-        data_source_results = json.dumps(self.request_args["results"] )
+        data_source_results = self.request_args["results"]
 
         self.logger.debug(data_source_results)
         translation_module = self.connection['type'].lower()


### PR DESCRIPTION
Modifications to STIX Shifter to make it work as proxy host mode with QRadar and CP4S 1.3.0.1

