### PR TITLE
Value escaping in LIKE is unnecessary and changes the value in QRadar

### DIFF
--- a/stix_shifter_modules/qradar/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/qradar/stix_translation/query_constructor.py
@@ -79,8 +79,7 @@ class AqlQueryStringPatternTranslator:
 
     @staticmethod
     def _format_like(value) -> str:
-        value = "'%{value}%'".format(value=value)
-        return AqlQueryStringPatternTranslator._escape_value(value)
+        return "'%{value}%'".format(value=value)
 
     @staticmethod
     def _escape_value(value, comparator=None) -> str:


### PR DESCRIPTION
Following issue #370 

given the following STIX pattern: `[(process:command_line LIKE 'my command line is (here)')]`, when translating to AQL, the value is escaped and now is `LIKE '%my command line is \(here\)%'` which is different from `'my command line is (here)'` in QRadar, and will not return the intended results.

Occurs as well for LIKE clause where value has " sign as well, for example:
`ProcessCommandLine LIKE '%% /C type nul > \"C:\Users\\%\Desktop\\%.exe%' != ProcessCommandLine LIKE '%% /C type nul > "C:\Users\\%\Desktop\\%.exe%'`
