### PR TITLE
fix: keeping data source terminology consistent

### DIFF
--- a/stix_shifter_modules/alertflex/configuration/lang_en.json
+++ b/stix_shifter_modules/alertflex/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Help",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "sni": {
             "label": "Server Name Indicator",
@@ -19,7 +19,7 @@
         },
         "selfSignedCert": {
             "label": "Alertflex Connection Certificate",
-            "description": "Use self-signed SSL certificate and CA content(root and intermediate) of datasource"
+            "description": "Use self-signed SSL certificate and CA content(root and intermediate) of data source"
         }
     },
     "configuration": {

--- a/stix_shifter_modules/async_dummy/configuration/lang_en.json
+++ b/stix_shifter_modules/async_dummy/configuration/lang_en.json
@@ -11,11 +11,11 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": "<Module> Connection Certificate",
-            "description": "Use self-signed SSL certificate and CA content(root and intermediate) of datasource"
+            "description": "Use self-signed SSL certificate and CA content(root and intermediate) of data source"
         },
         "sni": {
             "label": "Server Name Indicator",

--- a/stix_shifter_modules/aws_cloud_watch_logs/configuration/lang_en.json
+++ b/stix_shifter_modules/aws_cloud_watch_logs/configuration/lang_en.json
@@ -2,7 +2,7 @@
     "connection": {
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "region": {
             "label": "Region",

--- a/stix_shifter_modules/azure_sentinel/configuration/lang_en.json
+++ b/stix_shifter_modules/azure_sentinel/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": "IBM QRadar Certificate",

--- a/stix_shifter_modules/bigfix/configuration/lang_en.json
+++ b/stix_shifter_modules/bigfix/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": "BigFix Certificate",

--- a/stix_shifter_modules/carbonblack/configuration/lang_en.json
+++ b/stix_shifter_modules/carbonblack/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": "CB Response connection certificate",

--- a/stix_shifter_modules/elastic_ecs/configuration/lang_en.json
+++ b/stix_shifter_modules/elastic_ecs/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": " Elasticsearch connection certificate",

--- a/stix_shifter_modules/guardium/configuration/lang_en.json
+++ b/stix_shifter_modules/guardium/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": "Guardium connection certificate",

--- a/stix_shifter_modules/lang_en.json
+++ b/stix_shifter_modules/lang_en.json
@@ -1,14 +1,14 @@
 {
     "connection": {
         "type": {
-            "description": "Datasource type"
+            "description": "Data source type"
         },
         "name": {
-            "label": "Data Source Name",
+            "label": "Data source name",
             "placeholder": "Add a data source name"
         },
         "description": {
-            "label": "Data Source Description",
+            "label": "Data source description",
             "placeholder": "Add a data source description"
         },
         "options": {
@@ -26,11 +26,11 @@
             },
             "dialects": {
                 "label": "Dialect",
-                "description": "If datasource needs to search multiple schema or database tables"
+                "description": "If data source needs to search multiple schema or database tables"
             },
             "validate_pattern": {
                 "label": "STIX Pattern Validator",
-                "description": "Validate STIX patterns that needs to be translated into native datasource query"
+                "description": "Validate STIX patterns that needs to be translated into native data source query"
             },
             "stix_validator": {
                 "label": "STIX Object Validator",

--- a/stix_shifter_modules/msatp/configuration/lang_en.json
+++ b/stix_shifter_modules/msatp/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": "Microsoft Defender ATP Certificate",

--- a/stix_shifter_modules/proxy/configuration/lang_en.json
+++ b/stix_shifter_modules/proxy/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         }
     },
     "configuration": {

--- a/stix_shifter_modules/qradar/configuration/lang_en.json
+++ b/stix_shifter_modules/qradar/configuration/lang_en.json
@@ -24,7 +24,7 @@
         },
         "data_lake": {
             "label": "Data Lake",
-            "description": "Enable Data Lake datasource"
+            "description": "Enable Data Lake data source"
         },
         "options": {
             "hash_options": {

--- a/stix_shifter_modules/security_advisor/configuration/lang_en.json
+++ b/stix_shifter_modules/security_advisor/configuration/lang_en.json
@@ -6,7 +6,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         }
     },
     "configuration": {

--- a/stix_shifter_modules/splunk/configuration/lang_en.json
+++ b/stix_shifter_modules/splunk/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "selfSignedCert": {
             "label": "Splunk connection certificate",

--- a/stix_shifter_modules/stix_bundle/configuration/lang_en.json
+++ b/stix_shifter_modules/stix_bundle/configuration/lang_en.json
@@ -11,7 +11,7 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         }
     },
     "configuration": {

--- a/stix_shifter_modules/synchronous_dummy/configuration/lang_en.json
+++ b/stix_shifter_modules/synchronous_dummy/configuration/lang_en.json
@@ -11,11 +11,11 @@
         },
         "help": {
             "label": "Need additional help?",
-            "description": "More details on the datasource setting can be found in the specified link"
+            "description": "More details on the data source setting can be found in the specified link"
         },
         "cert": {
             "label": "Synchronous dummy Connection Certificate",
-            "description": "Use self-signed SSL certificate and CA content(root and intermediate) of datasource"
+            "description": "Use self-signed SSL certificate and CA content(root and intermediate) of data source"
         },
         "sni": {
             "label": "Server Name Indicator",


### PR DESCRIPTION
Standardizing data source text in lang files