### PR TITLE
missing `registry` and `dns` in query to ecs

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_transmission/api_client.py
+++ b/stix_shifter_modules/elastic_ecs/stix_transmission/api_client.py
@@ -88,7 +88,7 @@ class APIClient():
             data = {
                 "_source": {
                     "includes": ["@timestamp", "source.*", "destination.*", "event.*", "client.*", "server.*",
-                                 "host.*","network.*", "process.*", "user.*", "file.*", "url.*"]
+                                 "host.*","network.*", "process.*", "user.*", "file.*", "url.*", "registry.*", "dns.*"]
                 },
                 "query": {
                     "query_string": {


### PR DESCRIPTION
There are mapping to STIX of fields like registry and dns in the mapping file, but if you take a look into the api_client you can notice that those keys registry and dns are not being query from elastic at all. The suggested fix I did is here (working okay) - https://github.com/barvhaim/stix-shifter/commit/a2c1a5a969a48dc8905634ac808ab30779af0b8c