### PR TITLE
Elastic ECS translation with LIKE operator incorrect results

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/query_constructor.py
@@ -56,7 +56,7 @@ class QueryStringPatternTranslator:
     def _format_like(value) -> str:
         # Replacing value with % to * and _ to ? for to support Like comparator
         if isinstance(value, str):
-            return '{}'.format(value.replace('%', '*').replace('_', '?'))
+            return '"{}"'.format(value.replace('%', '*').replace('_', '?'))
         else:
             return value
 


### PR DESCRIPTION
A query translation for elastic_ecs datasource that contains LIKE operator with a wildcard is behaving incorrectly when there is whitespace between the terms, for example the query "[(x-event:action LIKE 'Registry %')]" which should look for an event action that starts with Registry , will look for matching Registry OR % individually instead. query should result in `event.aciton : "Registry *"` and not `event.aciton : Registry *`