### PR TITLE
fix QRadar translation of combined observation expression with qualifier

### DIFF
--- a/stix_shifter_modules/qradar/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/qradar/stix_translation/query_constructor.py
@@ -274,11 +274,10 @@ class AqlQueryStringPatternTranslator:
             return self._parse_observation_expression(self, expression, qualifier)
         elif hasattr(expression, 'qualifier') and hasattr(expression, 'observation_expression'):
             if isinstance(expression.observation_expression, CombinedObservationExpression):
-                operator = self._lookup_comparison_operator(self, expression.observation_expression.operator)
-                # qualifier only needs to be passed into the parse expression once since it will be the same for both expressions
-                return "{expr1} {operator} {expr2}".format(expr1=self._parse_expression(expression.observation_expression.expr1),
-                                                           operator=operator,
-                                                           expr2=self._parse_expression(expression.observation_expression.expr2, expression.qualifier))
+                self._parse_expression(expression.observation_expression.expr1, expression.qualifier)
+                self._parse_expression(expression.observation_expression.expr2, expression.qualifier)
+                
+                return ''
             else:
                 return self._parse_expression(expression.observation_expression.comparison_expression, expression.qualifier)
         elif isinstance(expression, CombinedObservationExpression):

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
@@ -96,3 +96,12 @@ class TestStixToAql(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         where_statement = "WHERE TEXT SEARCH '%New-Item% AND %Set-ItemProperty%' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_combined_observation_expression_with_qualifier(self):
+        stix_pattern = "([ipv4-addr:value = '192.168.1.2'] OR [network-traffic:src_port = 8080]) START t'2020-09-11T13:00:52.000Z' STOP t'2020-09-11T13:59:04.000Z'"
+        query = _translate_query(stix_pattern)
+        where_statement_01 = "WHERE (sourceip = '192.168.1.2' OR destinationip = '192.168.1.2') limit 10000 START 1599829252000 STOP 1599832744000"
+        where_statement_02 = "WHERE sourceport = '8080' limit 10000 START 1599829252000 STOP 1599832744000"
+        assert len(query['queries']) == 2
+        assert query['queries'][0] == selections + from_statement + where_statement_01
+        assert query['queries'][1] == selections + from_statement + where_statement_02


### PR DESCRIPTION
Test pattern: 
`python main.py translate qradar query '{}' "([ipv4-addr:value = '192.168.1.2'] OR [url:value LIKE '%.example.com']) START t'2020-09-11T13:00:52.000Z' STOP t'2020-09-11T13:59:04.000Z'"`

START STOP qualifier should be applied to all the translated QRadar queries. 