### PR TITLE
Added opened_connection_refs to process SCO in elastic_ecs module

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -507,24 +507,42 @@
     }
   },
   "network": {
-    "transport": {
+    "transport": [{
       "key": "network-traffic.protocols",
       "object": "nt",
       "group": "True",
       "transformer": "ToLowercaseArray"
-    },
-    "type": {
+    }, {
+        "key": "process.opened_connection_refs",
+        "object": "process",
+        "references": [
+          "nt"
+        ]
+    }],
+    "type": [{
       "key": "network-traffic.protocols",
       "object": "nt",
       "group": "True",
       "transformer": "ToLowercaseArray"
-    },
-    "protocol": {
+    }, {
+        "key": "process.opened_connection_refs",
+        "object": "process",
+        "references": [
+          "nt"
+        ]
+    }],
+    "protocol": [{
       "key": "network-traffic.protocols",
       "object": "nt",
       "group": "True",
       "transformer": "ToLowercaseArray"
-    },
+    }, {
+        "key": "process.opened_connection_refs",
+        "object": "process",
+        "references": [
+          "nt"
+        ]
+    }],
     "vlan": {
       "id": {
         "key": "x-ecs-network.vlan_id",

--- a/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
+++ b/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
@@ -227,7 +227,7 @@ class TestElasticEcsTransform(unittest.TestCase, object):
         proc_object = TestElasticEcsTransform.get_first_of_type(objects.values(), 'process')
         assert (proc_object is not None), 'process object type not found'
         assert (proc_object.keys() ==
-                {'type', 'pid', 'name', 'created', 'creator_user_ref', 'binary_ref'})
+                {'type', 'pid', 'name', 'created', 'opened_connection_refs', 'creator_user_ref', 'binary_ref'})
         assert (proc_object['type'] == 'process')
         assert (proc_object['pid'] == 609)
         assert (proc_object['created'] == '2019-04-10T11:33:57.571Z')


### PR DESCRIPTION
According to the stix 2.0 spec process SCO has an optional property `opened_connection_refs` which "Specifies the list of network connections opened by the process, as a reference to one or more Network Traffic Objects."

This PR adds this reference to `process` in the lastic_ecs module and updates the tests accordingly