### PR TITLE
stix_bundle: Drop duplicate matches from cti-pattern-matcher

### DIFF
--- a/stix_shifter_modules/stix_bundle/stix_transmission/connector.py
+++ b/stix_shifter_modules/stix_bundle/stix_transmission/connector.py
@@ -37,7 +37,8 @@ class Connector(BaseSyncConnector):
         if found_bindings:
             matching_sdos = []
             for binding in found_bindings:
-                matching_sdos = matching_sdos + matcher.get_sdos_from_binding(binding)
+                matches = [match for match in matcher.get_sdos_from_binding(binding) if match not in matching_sdos]
+                matching_sdos.extend(matches)
         else:
             matching_sdos = []
 


### PR DESCRIPTION
The stix_bundle connector is returning duplicate results when the bundle contains observations with number_observed > 1.  The root cause is here in cti-pattern-matcher: https://github.com/oasis-open/cti-pattern-matcher/blob/bcd37eeb8c44e012ff1dbe4434c510f343575840/stix2matcher/matcher.py#L1006

However, since the pattern matcher really only needs to return true or false, I can't say that duplicating the SDO in there is a bug.  I would argue that the bundle connector needs to drop those duplicates.

This commit drops a match if it's already in the list of matching SDOs.  There is likely a better/more efficient way to do this; this change is quick and dirty.