### PR TITLE
fix elastics_ecs to apply the time range correctly

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/query_constructor.py
@@ -167,7 +167,7 @@ class QueryStringPatternTranslator:
                 expression_01 = "({})".format(expression_01)
             if isinstance(expression.expr2, CombinedComparisonExpression):
                 expression_02 = "({})".format(expression_02)
-            query_string = "{} {} {}".format(expression_01, operator, expression_02)
+            query_string = "({} {} {})".format(expression_01, operator, expression_02)
             if qualifier is not None:
                 self.qualified_queries.append("{} {}".format(query_string, qualifier))
                 return ''

--- a/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_stix_to_query.py
+++ b/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_stix_to_query.py
@@ -40,7 +40,7 @@ class TestStixtoQuery(unittest.TestCase, object):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83' OR ipv4-addr:value = '192.168.122.84']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
-        test_query = ['(source.ip : "192.168.122.84" OR destination.ip : "192.168.122.84" OR client.ip : "192.168.122.84" OR server.ip : "192.168.122.84" OR host.ip : "192.168.122.84" OR dns.resolved_ip : "192.168.122.84") OR (source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83" OR host.ip : "192.168.122.83" OR dns.resolved_ip : "192.168.122.83")']
+        test_query = ['((source.ip : "192.168.122.84" OR destination.ip : "192.168.122.84" OR client.ip : "192.168.122.84" OR server.ip : "192.168.122.84" OR host.ip : "192.168.122.84" OR dns.resolved_ip : "192.168.122.84") OR (source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83" OR host.ip : "192.168.122.83" OR dns.resolved_ip : "192.168.122.83"))']
         _test_query_assertions(translated_query, test_query)
 
     def test_ipv6_query(self):
@@ -75,7 +75,7 @@ class TestStixtoQuery(unittest.TestCase, object):
         stix_pattern = "[(url:value = 'www.example.com' OR url:value = 'www.test.com') AND mac-addr:value = '00-00-5E-00-53-00']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
-        test_query = ['(source.mac : "00-00-5E-00-53-00" OR destination.mac : "00-00-5E-00-53-00" OR client.mac : "00-00-5E-00-53-00" OR server.mac : "00-00-5E-00-53-00" OR host.mac : "00-00-5E-00-53-00") AND (url.original : "www.test.com" OR url.original : "www.example.com")']
+        test_query = ['((source.mac : "00-00-5E-00-53-00" OR destination.mac : "00-00-5E-00-53-00" OR client.mac : "00-00-5E-00-53-00" OR server.mac : "00-00-5E-00-53-00" OR host.mac : "00-00-5E-00-53-00") AND ((url.original : "www.test.com" OR url.original : "www.example.com")))']
         _test_query_assertions(translated_query, test_query)
 
     def test_file_query(self):
@@ -89,8 +89,8 @@ class TestStixtoQuery(unittest.TestCase, object):
         stix_pattern = "[network-traffic:protocols[*] LIKE 'ipv_' AND network-traffic:src_port>443] START t'2019-04-11T08:42:39.297Z' STOP t'2019-04-11T08:43:39.297Z' OR [user-account:user_id = '_' AND artifact:payload_bin LIKE '%'] START t'2019-04-11T14:35:44.011Z' STOP t'2019-04-21T16:35:44.011Z' AND [process:pid<700 OR url:value LIKE '%' AND process:creator_user_ref.user_id IN ('root','admin')] START t'2019-04-11T14:35:44.011Z' STOP t'2019-04-17T14:35:44.011Z'"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         print(str(translated_query))
-        test_query = ['(source.port:>443 OR client.port:>443) AND (network.transport : ipv? OR network.type : ipv? OR network.protocol : ipv?) AND (@timestamp:["2019-04-11T08:42:39.297Z" TO "2019-04-11T08:43:39.297Z"])',
-                      'event.original : * AND (user.name : "_" OR user.id : "_") AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-21T16:35:44.011Z"])', '(user.name : ("root" OR "admin") AND url.original : *) OR (process.pid:<700 OR process.ppid:<700 OR process.parent.pid:<700 OR process.parent.ppid:<700) AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-17T14:35:44.011Z"])']
+        test_query = ['((source.port:>443 OR client.port:>443) AND (network.transport : ipv? OR network.type : ipv? OR network.protocol : ipv?)) AND (@timestamp:["2019-04-11T08:42:39.297Z" TO "2019-04-11T08:43:39.297Z"])',
+                      '(event.original : * AND (user.name : "_" OR user.id : "_")) AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-21T16:35:44.011Z"])', '(((user.name : ("root" OR "admin") AND url.original : *)) OR (process.pid:<700 OR process.ppid:<700 OR process.parent.pid:<700 OR process.parent.ppid:<700)) AND (@timestamp:["2019-04-11T14:35:44.011Z" TO "2019-04-17T14:35:44.011Z"])']
         assert translated_query['queries'] == test_query
 
     def test_file_not_equal_query(self):
@@ -104,14 +104,14 @@ class TestStixtoQuery(unittest.TestCase, object):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:dst_port = 23456]"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
-        test_query = ['(destination.port : "23456" OR server.port : "23456") OR (source.port : "12345" OR client.port : "12345")']
+        test_query = ['((destination.port : "23456" OR server.port : "23456") OR (source.port : "12345" OR client.port : "12345"))']
         _test_query_assertions(translated_query, test_query)
 
     def test_port_queries_lessthan_greaterthan(self):
         stix_pattern = "[network-traffic:src_port > 12345 AND network-traffic:dst_port < 23456]"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
-        test_query = ['(destination.port:<23456 OR server.port:<23456) AND (source.port:>12345 OR client.port:>12345)']
+        test_query = ['((destination.port:<23456 OR server.port:<23456) AND (source.port:>12345 OR client.port:>12345))']
         _test_query_assertions(translated_query, test_query)
 
     def test_port_queries_src_ref_equal(self):
@@ -153,7 +153,7 @@ class TestStixtoQuery(unittest.TestCase, object):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:protocols[*] LIKE '_n%']"
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'] = _remove_timestamp_from_query(translated_query['queries'])
-        test_query = ['(network.transport : ?n* OR network.type : ?n* OR network.protocol : ?n*) OR (source.port : "12345" OR client.port : "12345")']
+        test_query = ['((network.transport : ?n* OR network.type : ?n* OR network.protocol : ?n*) OR (source.port : "12345" OR client.port : "12345"))']
         _test_query_assertions(translated_query, test_query)
 
     def test_unmapped_attribute_handling_with_OR(self):
@@ -226,7 +226,7 @@ class TestStixtoQuery(unittest.TestCase, object):
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'][-1] = _remove_timestamp_from_query(translated_query['queries'][-1])
         test_query = ['(source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83" OR host.ip : "192.168.122.83" OR dns.resolved_ip : "192.168.122.83") AND (@timestamp:["2019-04-01T01:30:00.123Z" TO "2019-04-01T02:20:00.123Z"])',
-                      '(user.name : "root" OR user.id : "root") AND (source.port : "37020" OR client.port : "37020")']
+                      '((user.name : "root" OR user.id : "root") AND (source.port : "37020" OR client.port : "37020"))']
         assert len(translated_query['queries']) == 2
         _test_query_assertions(translated_query, test_query)
 
@@ -237,7 +237,7 @@ class TestStixtoQuery(unittest.TestCase, object):
         stop_time_02 = "t'2019-04-01T04:30:24.743Z'"
         stix_pattern = "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] START {} STOP {} OR [ipv4-addr:value = '192.168.122.83'] START {} STOP {}".format(start_time_01, stop_time_01, start_time_02, stop_time_02)
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
-        test_query = ['(user.name : "root" OR user.id : "root") AND (source.port : "37020" OR client.port : "37020") AND (@timestamp:["2019-04-01T01:30:00.123Z" TO "2019-04-01T02:20:00.123Z"])',
+        test_query = ['((user.name : "root" OR user.id : "root") AND (source.port : "37020" OR client.port : "37020")) AND (@timestamp:["2019-04-01T01:30:00.123Z" TO "2019-04-01T02:20:00.123Z"])',
                       '(source.ip : "192.168.122.83" OR destination.ip : "192.168.122.83" OR client.ip : "192.168.122.83" OR server.ip : "192.168.122.83" OR host.ip : "192.168.122.83" OR dns.resolved_ip : "192.168.122.83") AND (@timestamp:["2019-04-01T03:55:00.123Z" TO "2019-04-01T04:30:24.743Z"])']
         assert len(translated_query['queries']) == 2
         _test_query_assertions(translated_query, test_query)
@@ -251,9 +251,15 @@ class TestStixtoQuery(unittest.TestCase, object):
             start_time_01, stop_time_01, start_time_02, stop_time_02)
         translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
         translated_query['queries'][-1] = _remove_timestamp_from_query(translated_query['queries'][-1])
-        test_query = ['(destination.port : "635" OR server.port : "635") AND (source.port : "37020" OR client.port : "37020") AND (@timestamp:["2019-04-01T00:00:00.123Z" TO "2019-04-01T01:11:11.456Z"])',
+        test_query = ['((destination.port : "635" OR server.port : "635") AND (source.port : "37020" OR client.port : "37020")) AND (@timestamp:["2019-04-01T00:00:00.123Z" TO "2019-04-01T01:11:11.456Z"])',
                       '(source.ip : "333.333.333.0" OR destination.ip : "333.333.333.0" OR client.ip : "333.333.333.0" OR server.ip : "333.333.333.0" OR host.ip : "333.333.333.0" OR dns.resolved_ip : "333.333.333.0") AND (@timestamp:["2019-04-07T02:22:22.789Z" TO "2019-04-07T03:33:33.012Z"])', 'url.original : "www.example.com"']
         assert len(translated_query['queries']) == 3
+        _test_query_assertions(translated_query, test_query)
+
+    def test_start_stop_qualifiers_with_OR_query(self):
+        stix_pattern = "[url:value = 'http://www.testaddress.com' OR  user-account:user_id = 'root'] START t'2021-01-17T14:15:44.000Z' STOP t'2021-01-17T15:15:00.000Z'"
+        translated_query = translation.translate('elastic_ecs', 'query', '{}', stix_pattern)
+        test_query = ['((user.name : "root" OR user.id : "root") OR url.original : "http://www.testaddress.com") AND (@timestamp:["2021-01-17T14:15:44.000Z" TO "2021-01-17T15:15:00.000Z"])']
         _test_query_assertions(translated_query, test_query)
 
     def test_match_operator(self):


### PR DESCRIPTION
Fixes issue https://github.com/opencybersecurityalliance/stix-shifter/issues/495

When the STIX query contains multiple statements joined with OR, the generated elastic_ecs query is incorrect and applies the time range to only one of the statements due to missing bracketing.

For example:
Running the following STIX query works and returns a match for the IP address:
`[ipv4-addr:value = '192.168.0.5'] START t'2020-09-06T23:00:00.000Z' STOP t'2020-09-13T23:00:00.000Z'`

However the following query returns nothing when it should have returned the same result as above (user nosuchuser does not exist but this shouldn’t affect the results since it is an OR)
`[user-account:user_id = 'nosuchuser' OR ipv4-addr:value = '192.168.0.5'] START t'2020-09-06T23:00:00.000Z' STOP t'2020-09-13T23:00:00.000Z'`

The reason is a bug in elastic_ecs stix shifter module. It translates this query as follows:
`(source.ip : "192.168.0.5" OR destination.ip : "192.168.0.5" OR client.ip : "192.168.0.5" OR server.ip : "192.168.0.5" OR host.ip : "192.168.0.5" OR dns.resolved_ip : "192.168.0.5") OR (user.name : "nosuchuser" OR user.id : “nosuchuser") AND (@timestamp:["2020-09-06T23:00:00.000Z" TO "2020-09-13T23:00:00.000Z"])`

This translation is incorrect and only applies the time range to the user part of the query. It should have added brackets around the first part of the query before the AND since timestamp needs to apply to both. 

The correct elastic ecs query translation should be:
`((source.ip : "192.168.0.5" OR destination.ip : "192.168.0.5" OR client.ip : "192.168.0.5" OR server.ip : "192.168.0.5" OR host.ip : "192.168.0.5" OR dns.resolved_ip : "192.168.0.5") OR (user.name : "nosuchuser" OR user.id : “nosuchuser")) AND (@timestamp:["2020-09-06T23:00:00.000Z" TO "2020-09-13T23:00:00.000Z"])`

