### PR TITLE
corrected reference for ECS mapping of process.parent.executable

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -982,7 +982,7 @@
         {
           "key": "x-oca-event.parent_process_ref",
           "object": "event",
-          "references": "process"
+          "references": "process_parent"
         }
       ]
     },


### PR DESCRIPTION
There is a bug in the mapping def for the ECS attribute process.parent.executable which creates x-oca-event:parent_process_ref in STIX. The present mapping wrongly refers to 'process' which is the STIX COO created for the actual process. Instead, it should refer to the STIX COO created for the parent process which is 'process_parent'. 

