### PR TITLE
rename proxy host data parameters

### DIFF
--- a/stix_shifter_utils/utils/proxy_host.py
+++ b/stix_shifter_utils/utils/proxy_host.py
@@ -19,13 +19,13 @@ class ProxyHost():
             self.options = self.request_args.get("options", {})
 
     def transform_query(self):
-        query = self.request_args["query"]
+        query = self.request_args["data"]
         translation = stix_translation.StixTranslation()
         dsl = translation.translate(self.module, 'query', '{}', query, self.options)
         return json.dumps(dsl)
 
     def translate_results(self, data_source_identity_object):
-        data_source_results = self.request_args["results"]
+        data_source_results = self.request_args["data"]
         data_source = self.request_args.get("data_source")
         if data_source_identity_object:
             data_source = data_source_identity_object


### PR DESCRIPTION
following those changes:
https://github.com/opencybersecurityalliance/stix-shifter/commit/35fcc5957d197c32d78a7c716a09b79998f6d840
proxy_host.py should be update to support the change of renaming the data field in transform_query and translate_results from "query" and "result" to "data"