### PR TITLE
Support QRadar offense fields and function

### DIFF
--- a/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
@@ -67,6 +67,7 @@
     "UrlHost",
     "\"Process Name\" as ProcessName",
     "\"Process ID\" as ProcessId",
-    "\"Parent Process ID\" as ParentProcessId"
+    "\"Parent Process ID\" as ParentProcessId",
+    "hasOffense"
   ]
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
@@ -68,6 +68,6 @@
     "\"Process Name\" as ProcessName",
     "\"Process ID\" as ProcessId",
     "\"Parent Process ID\" as ParentProcessId",
-    "hasOffense"
+    "hasoffense"
   ]
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/aql_flows_fields.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/aql_flows_fields.json
@@ -71,6 +71,7 @@
     "\"tls ja3s hash\" as tlsja3shash",
     "\"suspect content descriptions\" as suspectcontentdescriptions",
     "flowid",
-    "\"content type\" as contenttype"
+    "\"content type\" as contenttype",
+    "hasOffense"
   ]
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/aql_flows_fields.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/aql_flows_fields.json
@@ -71,7 +71,6 @@
     "\"tls ja3s hash\" as tlsja3shash",
     "\"suspect content descriptions\" as suspectcontentdescriptions",
     "flowid",
-    "\"content type\" as contenttype",
-    "hasOffense"
+    "\"content type\" as contenttype"
   ]
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
@@ -73,7 +73,8 @@
       "severity": ["eventseverity"],
       "credibility": ["credibility"],
       "relevance": ["relevance"],
-      "domain_id": ["domainid"]
+      "domain_id": ["domainid"],
+      "has_offense": ["hasOffense"]
     }
   },
   "x-ibm-finding": {

--- a/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
@@ -74,7 +74,8 @@
       "credibility": ["credibility"],
       "relevance": ["relevance"],
       "domain_id": ["domainid"],
-      "has_offense": ["hasOffense"]
+      "has_offense": ["hasOffense"],
+      "INOFFENSE": ["INOFFENSE"]
     }
   },
   "x-ibm-finding": {

--- a/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
@@ -74,7 +74,7 @@
       "credibility": ["credibility"],
       "relevance": ["relevance"],
       "domain_id": ["domainid"],
-      "has_offense": ["hasOffense"],
+      "has_offense": ["hasoffense"],
       "INOFFENSE": ["INOFFENSE"]
     }
   },

--- a/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
@@ -84,7 +84,8 @@
       "tls_server_name_indication": [ "tlsservernameindication" ],
       "tls_ja3_hash": [ "tlsja3hash" ],
       "tls_ja3s_hash": [ "tlsja3shash" ],
-      "suspect_content_descriptions": [ "suspectcontentdescriptions" ]
+      "suspect_content_descriptions": [ "suspectcontentdescriptions" ],
+      "has_offense": ["hasOffense"]
     }
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
@@ -85,7 +85,7 @@
       "tls_ja3_hash": [ "tlsja3hash" ],
       "tls_ja3s_hash": [ "tlsja3shash" ],
       "suspect_content_descriptions": [ "suspectcontentdescriptions" ],
-      "has_offense": ["hasOffense"],
+      "has_offense": ["hasoffense"],
       "INOFFENSE": ["INOFFENSE"]
     }
   }

--- a/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
@@ -85,7 +85,8 @@
       "tls_ja3_hash": [ "tlsja3hash" ],
       "tls_ja3s_hash": [ "tlsja3shash" ],
       "suspect_content_descriptions": [ "suspectcontentdescriptions" ],
-      "has_offense": ["hasOffense"]
+      "has_offense": ["hasOffense"],
+      "INOFFENSE": ["INOFFENSE"]
     }
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -873,7 +873,7 @@
       "references": ["service_file_name"]
     }
   ],
-  "hasOffense": {
+  "hasoffense": {
     "key": "x-qradar.has_offense",
     "object": "x-qradar"
   }

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -115,8 +115,8 @@
     },
     {
       "key": "x-ibm-finding.dst_ip_ref",
-      "object": "finding", 
-      "references": "dst_ip" 
+      "object": "finding",
+      "references": "dst_ip"
     },
     {
       "key": "x-oca-event.network_ref",
@@ -223,8 +223,8 @@
     },
     {
       "key": "x-ibm-finding.src_ip_ref",
-      "object": "finding", 
-      "references": "src_ip" 
+      "object": "finding",
+      "references": "src_ip"
     },
     {
       "key": "x-oca-asset.ip_refs",
@@ -872,5 +872,9 @@
       "group": true,
       "references": ["service_file_name"]
     }
-  ]
+  ],
+  "hasOffense": {
+    "key": "x-qradar.has_offense",
+    "object": "x-qradar"
+  }
 }

--- a/stix_shifter_modules/qradar/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/qradar/stix_translation/query_constructor.py
@@ -16,6 +16,8 @@ REFERENCE_DATA_TYPES = {"sourceip": ["ipv4", "ipv6", "ipv4_cidr", "ipv6_cidr"],
                         "sourcev6": ["ipv6", "ipv6_cidr"],
                         "destinationv6": ["ipv6", "ipv6_cidr"]}
 
+FILTERING_DATA_TYPES = {"x-qradar:INOFFENSE": "INOFFENSE"}
+
 START_STOP_STIX_QUALIFIER = "START((t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z')|(\s\d{13}\s))STOP"
 TIMESTAMP = "^'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z'$"
 TIMESTAMP_MILLISECONDS = "\.\d+Z$"
@@ -123,7 +125,9 @@ class AqlQueryStringPatternTranslator:
 
         for mapped_field in mapped_fields_array:
             # if its a set operator() query construction will be different.
-            if expression.comparator == ComparisonComparators.IsSubSet:
+            if expression.object_path in FILTERING_DATA_TYPES.keys():
+                comparison_string += "{}({})".format(FILTERING_DATA_TYPES[expression.object_path], value)
+            elif expression.comparator == ComparisonComparators.IsSubSet:
                 comparison_string += comparator + "(" + "'" + value + "'," + mapped_field + ")"
             elif is_reference_value:
                 parsed_reference = self._parse_reference(self, stix_field, value_type, mapped_field, value, comparator)

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
@@ -428,7 +428,7 @@ class TestQueryTranslator(unittest.TestCase, object):
     def test_hasoffense_query(self):
         stix_pattern = "[x-qradar:has_offense = 'true']"
         query = _translate_query(stix_pattern)
-        where_statement = "WHERE hasOffense = 'true' {} {}".format(default_limit, default_time)
+        where_statement = "WHERE hasoffense = 'true' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_inoffense_query(self):

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
@@ -430,3 +430,9 @@ class TestQueryTranslator(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         where_statement = "WHERE hasOffense = 'true' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_inoffense_query(self):
+        stix_pattern = "[x-qradar:INOFFENSE = '125']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE INOFFENSE('125') {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
@@ -424,3 +424,9 @@ class TestQueryTranslator(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         where_statement = "WHERE str(destinationip) IN ('1.1.1.1', '2.2.2.2') OR destinationport IN ('22', '443') {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_hasoffense_query(self):
+        stix_pattern = "[x-qradar:has_offense = 'true']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE hasOffense = 'true' {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
@@ -249,3 +249,9 @@ class TestStixToAql(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         where_statement = "WHERE hasOffense = 'true' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_inoffense_query(self):
+        stix_pattern = "[x-qradar:INOFFENSE = '125']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE INOFFENSE('125') {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
@@ -247,7 +247,7 @@ class TestStixToAql(unittest.TestCase, object):
     def test_hasoffense_query(self):
         stix_pattern = "[x-qradar:has_offense = 'true']"
         query = _translate_query(stix_pattern)
-        where_statement = "WHERE hasOffense = 'true' {} {}".format(default_limit, default_time)
+        where_statement = "WHERE hasoffense = 'true' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_inoffense_query(self):

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
@@ -243,3 +243,9 @@ class TestStixToAql(unittest.TestCase, object):
         query = _translate_query(stix_pattern)
         where_statement = "WHERE str(destinationip) IN ('1.1.1.1', '2.2.2.2') OR destinationport IN ('22', '443') {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_hasoffense_query(self):
+        stix_pattern = "[x-qradar:has_offense = 'true']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE hasOffense = 'true' {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)


### PR DESCRIPTION
This PR adds offense related field and function in AQL for QRadar module.
Adding:

- field `hasOffense` - indicate association with and offense
- function `INOFFENSE` - used in where clause only, accepts an offense ID as argument and filters events/flows which relate to that offense. 

Note that `INOFFENSE` doesn't correspond to any field, and is used only in where clause.
Both `hasOffense` and `INOFFENSE` are supported both in events and flows
