### PR TITLE
Fix to support multiple Python versions

### DIFF
--- a/stix_shifter_utils/utils/module_discovery.py
+++ b/stix_shifter_utils/utils/module_discovery.py
@@ -26,7 +26,7 @@ def __split_module_dialects(module_dialects):
 
 def modules_list():
     modules = import_module('stix_shifter_modules')
-    if '__file__' in dir(modules):
+    if '__file__' in dir(modules) and modules.__file__ is not None:
         modules_path = Path(modules.__file__).parent
     else:
         modules_path = modules.__path__._path[0]
@@ -40,7 +40,7 @@ def modules_list():
 
 def dialect_list(module):
     modules = import_module('stix_shifter_modules')
-    if '__file__' in dir(modules):
+    if '__file__' in dir(modules) and modules.__file__ is not None:
         modules_path = Path(modules.__file__).parent
     else:
         modules_path = modules.__path__._path[0]


### PR DESCRIPTION
- Build/Test environments: Python v3.6.9, v3.7.5, v3.8.0 on Ubuntu 18.04
- Issue: Both locally built/installed and `pip` installed `stix-shifter` with Python v3.7+ encountered an error like reported here, https://github.com/opencybersecurityalliance/stix-shifter/issues/614
- Fix: `importlib.import_module` has different behaviors in Python v3.7+, e.g., `__file__` of the imported module can be `None`. Add a sanity check to address such cases in `stix_shifter_utils/utils/module_discovery.py`