### PR TITLE
fix invalid character in stix property

### DIFF
--- a/adapter-guide/connectors/azure_sentinel_supported_stix.md
+++ b/adapter-guide/connectors/azure_sentinel_supported_stix.md
@@ -7,9 +7,9 @@
 | domain-name | value | destinationDomain |
 | domain-name | value | domainName |
 | <br> | | |
-| extensions | windows-registry-value-type.valueData | registryKeyStates |
-| extensions | windows-registry-value-type.name | registryKeyStates |
-| extensions | windows-registry-value-type.valuetype | registryKeyStates |
+| extensions | windows_registry_value_type.valueData | registryKeyStates |
+| extensions | windows_registry_value_type.name | registryKeyStates |
+| extensions | windows_registry_value_type.valuetype | registryKeyStates |
 | <br> | | |
 | file | hashes.SHA-256 | sha256 |
 | file | hashes.SHA-1 | sha1 |

--- a/adapter-guide/connectors/qradar_supported_stix.md
+++ b/adapter-guide/connectors/qradar_supported_stix.md
@@ -63,13 +63,13 @@
 | network-traffic | src_packets | sourcepackets |
 | network-traffic | dst_packets | destinationpackets |
 | network-traffic | protocols | PROTOCOLNAME(protocolid) |
-| network-traffic | extensions.http-request-ext.request_header.Host | httphost |
-| network-traffic | extensions.http-request-ext.request_header.Referer | httpreferrer |
-| network-traffic | extensions.http-request-ext.request_header.Server | httpserver |
-| network-traffic | extensions.http-request-ext.request_header.User-Agent | httpuseragent |
-| network-traffic | extensions.http-request-ext.request_version | httpversion |
+| network-traffic | extensions.http_request_ext.request_header.Host | httphost |
+| network-traffic | extensions.http_request_ext.request_header.Referer | httpreferrer |
+| network-traffic | extensions.http_request_ext.request_header.Server | httpserver |
+| network-traffic | extensions.http_request_ext.request_header.User_Agent | httpuseragent |
+| network-traffic | extensions.http_request_ext.request_version | httpversion |
 | network-traffic | ipfix.flowId | flowid |
-| network-traffic | extensions.http-request-ext.request_header.Content-Type | contenttype |
+| network-traffic | extensions.http_request_ext.request_header.Content_Type | contenttype |
 | <br> | | |
 | process | creator_user_ref | username |
 | process | binary_ref | Image |
@@ -82,7 +82,7 @@
 | process | pid | "Process ID" |
 | process | pid | "Parent Process ID" |
 | process | parent_ref | "Parent Process ID" |
-| process | extensions.windows-service-ext.service_dll_refs | ServiceFileName |
+| process | extensions.windows_service_ext.service_dll_refs | ServiceFileName |
 | <br> | | |
 | software | name | applicationname |
 | <br> | | |

--- a/stix_shifter_modules/azure_sentinel/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/azure_sentinel/stix_translation/json/from_stix_map.json
@@ -77,9 +77,9 @@
   "windows-registry-key": {
     "fields": {
       "key": ["registryKeyStates.key"],
-      "extensions.windows-registry-value-type.valueData": [ "registryKeyStates.valueData" ],
-      "extensions.windows-registry-value-type.name": [ "registryKeyStates.valueName" ],
-      "extensions.windows-registry-value-type.valueType": [ "registryKeyStates.valueType" ]
+      "extensions.windows_registry_value_type.valueData": [ "registryKeyStates.valueData" ],
+      "extensions.windows_registry_value_type.name": [ "registryKeyStates.valueName" ],
+      "extensions.windows_registry_value_type.valueType": [ "registryKeyStates.valueType" ]
     }
   },
   "x-msazure-sentinel": {

--- a/stix_shifter_modules/azure_sentinel/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/azure_sentinel/stix_translation/json/to_stix_map.json
@@ -451,15 +451,15 @@
         "key": "process.pid"
       },
       "valueData": {
-        "key": "extensions.windows-registry-value-type.valueData",
+        "key": "extensions.windows_registry_value_type.valueData",
         "object": "registry"
       },
       "valueName": {
-        "key": "extensions.windows-registry-value-type.name",
+        "key": "extensions.windows_registry_value_type.name",
         "object": "registry"
       },
       "valueType": {
-        "key": "extensions.windows-registry-value-type.valuetype",
+        "key": "extensions.windows_registry_value_type.valuetype",
         "object": "registry",
         "transformer": "ToString"
       }

--- a/stix_shifter_modules/carbonblack/stix_translation/json/to_stix_map_events.json
+++ b/stix_shifter_modules/carbonblack/stix_translation/json/to_stix_map_events.json
@@ -105,7 +105,7 @@
       "references": "service_directory"
     },
     {
-      "key": "process.extensions.windows-service-ext.service_dll_refs",
+      "key": "process.extensions.windows_service_ext.service_dll_refs",
       "object": "process",
       "group": true,
       "references": ["service_file"]

--- a/stix_shifter_modules/msatp/stix_translation/transformers.py
+++ b/stix_shifter_modules/msatp/stix_translation/transformers.py
@@ -13,7 +13,7 @@ class MsatpToTimestamp(ValueTransformer):
 
 
 class MsatpToRegistryValue(ValueTransformer):
-    """A value transformer to convert MSATP Registry value protocol to windows-registry-value-type STIX"""
+    """A value transformer to convert MSATP Registry value protocol to windows_registry_value_type STIX"""
 
     @staticmethod
     def transform(registryvalues):

--- a/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
@@ -101,7 +101,7 @@
       "parent_ref.binary_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
-      "extensions.windows-service-ext.service_dll_refs[*].name": ["ServiceFileName"]
+      "extensions.windows_service_ext.service_dll_refs[*].name": ["ServiceFileName"]
     }
   },
   "x-oca-event": {

--- a/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
@@ -42,12 +42,12 @@
       "dst_byte_count": ["destinationbytes"],
       "src_packets": ["sourcepackets"],
       "dst_packets": ["destinationpackets"],
-      "extensions.http-request-ext.request_header.Host": [ "httphost" ],
-      "extensions.http-request-ext.request_header.Referer": [ "httpreferrer" ],
-      "extensions.http-request-ext.request_header.Server": [ "httpserver" ],
-      "extensions.http-request-ext.request_header.User-Agent": [ "httpuseragent" ],
-      "extensions.http-request-ext.request_header.Content-Type": [ "contenttype" ],
-      "extensions.http-request-ext.request_version": [ "httpversion" ],
+      "extensions.http_request_ext.request_header.Host": [ "httphost" ],
+      "extensions.http_request_ext.request_header.Referer": [ "httpreferrer" ],
+      "extensions.http_request_ext.request_header.Server": [ "httpserver" ],
+      "extensions.http_request_ext.request_header.User_Agent": [ "httpuseragent" ],
+      "extensions.http_request_ext.request_header.Content_Type": [ "contenttype" ],
+      "extensions.http_request_ext.request_version": [ "httpversion" ],
       "ipfix.flowId": [ "flowid" ]
     }
   },

--- a/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
@@ -16,7 +16,7 @@
       "hashes.SHA-256": [ "sha256hash" ],
       "hashes.MD5": [ "md5hash" ],
       "hashes.SHA-1": [ "sha1hash" ],
-      "mime-type": [ "contenttype" ]
+      "mime_type": [ "contenttype" ]
     }
   },
   "domain-name": {

--- a/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/flows_from_stix_map.json
@@ -42,7 +42,7 @@
       "dst_byte_count": ["destinationbytes"],
       "src_packets": ["sourcepackets"],
       "dst_packets": ["destinationpackets"],
-      "extensions.http_request_ext.request_header.Host": [ "httphost" ],
+      "extensions.'http-request-ext'.request_header.Host": [ "httphost" ],
       "extensions.http_request_ext.request_header.Referer": [ "httpreferrer" ],
       "extensions.http_request_ext.request_header.Server": [ "httpserver" ],
       "extensions.http_request_ext.request_header.User_Agent": [ "httpuseragent" ],

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -571,7 +571,7 @@
       "object": "url"
     },
     {
-      "key": "network-traffic.extensions.http_request_ext.request_header.Host",
+      "key": "network-traffic.extensions.'http-request-ext'.request_header.Host",
       "object": "nt"
     }
   ],

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -571,12 +571,12 @@
       "object": "url"
     },
     {
-      "key": "network-traffic.extensions.http-request-ext.request_header.Host",
+      "key": "network-traffic.extensions.http_request_ext.request_header.Host",
       "object": "nt"
     }
   ],
   "httpreferrer": {
-    "key": "network-traffic.extensions.http-request-ext.request_header.Referer",
+    "key": "network-traffic.extensions.http_request_ext.request_header.Referer",
     "object": "nt"
   },
   "httpresponsecode": {
@@ -584,15 +584,15 @@
     "object": "x-qradar"
   },
   "httpserver": {
-    "key": "network-traffic.extensions.http-request-ext.request_header.Server",
+    "key": "network-traffic.extensions.http_request_ext.request_header.Server",
     "object": "nt"
   },
   "httpuseragent": {
-    "key": "network-traffic.extensions.http-request-ext.request_header.User-Agent",
+    "key": "network-traffic.extensions.http_request_ext.request_header.User_Agent",
     "object": "nt"
   },
   "httpversion": {
-    "key": "network-traffic.extensions.http-request-ext.request_version",
+    "key": "network-traffic.extensions.http_request_ext.request_version",
     "object": "nt"
   },
   "tlsja3hash": {
@@ -615,7 +615,7 @@
   },
   "contenttype": [
     {
-      "key": "network-traffic.extensions.http-request-ext.request_header.Content-Type",
+      "key": "network-traffic.extensions.http_request_ext.request_header.Content_Type",
       "object": "nt"
     },
     {
@@ -867,7 +867,7 @@
       "references": "service_file_dir"
     },
     {
-      "key": "process.extensions.windows-service-ext.service_dll_refs",
+      "key": "process.extensions.windows_service_ext.service_dll_refs",
       "object": "process",
       "group": true,
       "references": ["service_file_name"]

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
@@ -155,7 +155,7 @@ class TestStixToAql(unittest.TestCase, object):
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_httpreqhost_query(self):
-        stix_pattern = "[network-traffic:extensions.http_request_ext.request_header.Host = 'example.com' ]"
+        stix_pattern = "[network-traffic:extensions.'http-request-ext'.request_header.Host = 'example.com' ]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE httphost = 'example.com' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
@@ -155,37 +155,37 @@ class TestStixToAql(unittest.TestCase, object):
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_httpreqhost_query(self):
-        stix_pattern = "[network-traffic:extensions.'http-request-ext'.'request_header'.Host = 'example.com' ]"
+        stix_pattern = "[network-traffic:extensions.http_request_ext.request_header.Host = 'example.com' ]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE httphost = 'example.com' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_httpreqreferer_query(self):
-        stix_pattern = "[network-traffic:extensions.'http-request-ext'.'request_header'.Referer = 'example.com' ]"
+        stix_pattern = "[network-traffic:extensions.http_request_ext.request_header.Referer = 'example.com' ]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE httpreferrer = 'example.com' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_httpreqserver_query(self):
-        stix_pattern = "[network-traffic:extensions.'http-request-ext'.'request_header'.Server = 'example.com' ]"
+        stix_pattern = "[network-traffic:extensions.http_request_ext.request_header.Server = 'example.com' ]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE httpserver = 'example.com' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_httprequseragent_query(self):
-        stix_pattern = "[network-traffic:extensions.'http-request-ext'.'request_header'.'User-Agent' = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0)' ]"
+        stix_pattern = "[network-traffic:extensions.http_request_ext.request_header.User_Agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0)' ]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE httpuseragent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0)' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_httpreqcontenttype_query(self):
-        stix_pattern = "[network-traffic:extensions.'http-request-ext'.'request_header'.'Content-Type' = 'application/json' ]"
+        stix_pattern = "[network-traffic:extensions.http_request_ext.request_header.Content_Type = 'application/json' ]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE contenttype = 'application/json' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_httprequestversion_query(self):
-        stix_pattern = "[network-traffic:extensions.'http-request-ext'.'request_version' = 'HTTP/1.1' ]"
+        stix_pattern = "[network-traffic:extensions.http_request_ext.request_version = 'HTTP/1.1' ]"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE httpversion = 'HTTP/1.1' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_flows_stix_to_query.py
@@ -137,7 +137,7 @@ class TestStixToAql(unittest.TestCase, object):
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_filetype_query(self):
-        stix_pattern = "[file:'mime-type' = 'application/json']"
+        stix_pattern = "[file:mime_type = 'application/json']"
         query = _translate_query(stix_pattern)
         where_statement = "WHERE contenttype = 'application/json' {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)


### PR DESCRIPTION
Based on stix grammar, the property doesn't include hyphen without quote, https://github.com/oasis-open/cti-stix2-json-schemas/blob/master/pattern_grammar/STIXPattern.g4#L77-L79

* correct file:mime_type
* correct qradar properties
* correct azure properties
