### PR TITLE
Added support to fetch alerts based on alert name.

### DIFF
--- a/stix_shifter_modules/splunk/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/splunk/stix_translation/query_constructor.py
@@ -152,8 +152,8 @@ class _ObservationExpressionTranslator:
             if stix_object == "x-readable-payload" and stix_path == "value":
                 return "_raw=*{}*".format(expression.value)
             # Special case where we want the risk finding
-            if stix_object == 'x-ibm-finding' and stix_path == 'name' and expression.value == "*":
-                return "index=_audit action=alert_fired"
+            if stix_object == 'x-ibm-finding' and stix_path == 'name':
+                return f'index=_audit ss_name="{expression.value}" action=alert_fired'
             # Check if mapping has multiple fields
             if isinstance(field_mapping, list):
                 comparison_string = ""

--- a/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -98,9 +98,9 @@ class TestStixToSpl(unittest.TestCase, object):
         _test_query_assertions(query, queries)
 
     def test_risk_finding(self):
-        stix_pattern = "[x-ibm-finding:name = '*']"
+        stix_pattern = "[x-ibm-finding:name = 'sample_alert']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
-        queries = 'search index=_audit action=alert_fired earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol, host, source, DeviceType, Direction, severity, EventID, EventName, ss_name, TacticId, Tactic, TechniqueId, Technique'
+        queries = 'search index=_audit ss_name="sample_alert" action=alert_fired earliest="-5minutes" | head 10000 | fields src_ip, src_port, src_mac, src_ipv6, dest_ip, dest_port, dest_mac, dest_ipv6, file_hash, user, url, protocol, host, source, DeviceType, Direction, severity, EventID, EventName, ss_name, TacticId, Tactic, TechniqueId, Technique'
         _test_query_assertions(query, queries)
 
     def test_port_queries(self):


### PR DESCRIPTION
In splunk we were only able to get all alerts using `x-ibm-finding:name = '*'` in addition to that added support to fetch alerts based on alert name.