### PR TITLE
add TTP tag mappings to elastic_ecs to close #706

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/from_stix_map.json
@@ -157,8 +157,7 @@
       "parent.code_signature.status": ["process.parent.code_signature.status"],
       "parent.code_signature.subject_name": ["process.parent.code_signature.subject_name"],
       "parent.code_signature.trusted": ["process.parent.code_signature.trusted"],
-      "parent.code_signature.valid": ["process.parent.code_signature.valid"],
-      "x_ttp_tags": ["tags"]
+      "parent.code_signature.valid": ["process.parent.code_signature.valid"]
     }
   },
   "url": {


### PR DESCRIPTION
Adding mappings to `from_stix_map.json` to make the query work. Not adding mappings to `to_stix_map.json` since `tags` is a top-level attribute, not under `process` in SysFlow's Elastic output, but it is not appropriate to add it as an attribute in a STIX observation. Full support requires new objects such as `x-ibm-findings`, which will be worked further (before or after our Black Hat demo) as mentioned in #706.