### PR TITLE
complete the SysFlow TTP tag mapping in Elastic ECS connector

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -2350,5 +2350,9 @@
         "object": "vulnerability"
       }
     }
+  },
+  "tags": {
+    "key": "process.x_ttp_tags",
+    "object": "process"
   }
 }

--- a/stix_shifter_modules/elastic_ecs/stix_transmission/api_client.py
+++ b/stix_shifter_modules/elastic_ecs/stix_transmission/api_client.py
@@ -91,7 +91,7 @@ class APIClient():
             data = {
                 "_source": {
                     "includes": ["@timestamp", "source.*", "destination.*", "event.*", "client.*", "server.*",
-                                 "host.*","network.*", "process.*", "user.*", "file.*", "url.*", "registry.*", "dns.*"]
+                                 "host.*","network.*", "process.*", "user.*", "file.*", "url.*", "registry.*", "dns.*", "tags"]
                 },
                 "query": {
                     "query_string": {


### PR DESCRIPTION
add the second half of the mapping for return results translation in `to_stix_map.json`.