### PR TITLE
Fix category in ecs to be list type

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -637,7 +637,8 @@
     },
     "category": {
       "key": "x-oca-event.category",
-      "object": "event"
+      "object": "event",
+      "transformer": "ValueToList"
     },
     "code": {
       "key": "x-oca-event.code",


### PR DESCRIPTION
According to the x-oca-event extension, category should be
a list of type string