### PR TITLE
fix instances of reserved STIX 2.1 id property

### DIFF
--- a/stix_shifter_modules/alertflex/stix_translation/json/stix_2_1/from_stix_map.json
+++ b/stix_shifter_modules/alertflex/stix_translation/json/stix_2_1/from_stix_map.json
@@ -1,0 +1,44 @@
+{
+  "ipv4-addr": {
+    "fields": {
+      "value": ["a.dstIp", "a.srcIp"]
+    }
+  },
+  "network-traffic": {
+    "fields": {
+      "src_port": ["a.srcPort"],
+      "dst_port": ["a.dstPort"],
+      "src_ref": ["a.srcIp"],
+      "dst_ref": ["a.dstIp"]
+    }
+  },
+  "file": {
+    "fields": {
+      "name": ["a.fileName"],
+      "hashes.'SHA-256'": ["a.hashSha256"],
+      "hashes.'SHA-1'": ["a.hashSha1"],
+      "hashes.MD5": ["a.hashMd5"]
+    }
+  },
+  "process": {
+    "fields": {
+      "name": ["a.processName"],
+      "pid": ["a.processId"]
+    }
+  },
+  "user-account":{
+    "fields": {
+      "user_id": ["a.userName"]
+    }
+  },
+  "x_org_alertflex" : {
+    "fields": {
+      "agent": ["a.agentName"],
+      "node": ["a.nodeId"],
+      "source": ["a.alertSource"],
+      "type": ["a.alertType"],
+      "event_id": ["a.eventId"],
+      "severity": ["a.alertSeverity"]
+    }
+  }
+}

--- a/stix_shifter_modules/alertflex/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/alertflex/stix_translation/json/stix_2_1/to_stix_map.json
@@ -1,0 +1,123 @@
+{
+  "create_time": [
+    {
+      "key": "first_observed",
+      "transformer": "EpochToTimestamp",
+      "cybox": false
+    },
+    {
+      "key": "last_observed",
+      "transformer": "EpochToTimestamp",
+      "cybox": false
+    }
+  ],
+  "srcip":
+        [
+            {
+                "key": "ipv4-addr.value",
+                "object": "src_ip"
+            },
+            {
+                "key": "ipv6-addr.value",
+                "object": "src_ip"
+            },
+            {
+                "key": "network-traffic.src_ref",
+                "object": "nt",
+                "references": "src_ip"
+            }
+        ],
+  "dstip": [
+      {
+      "key": "ipv4-addr.value",
+      "object": "dst_ip"
+      },
+      {
+        "key": "ipv6-addr.value",
+        "object": "dst_ip"
+      },
+      {
+        "key": "network-traffic.dst_ref",
+        "object": "nt",
+        "references": "dst_ip"
+      }
+    ],
+    "srcport": {
+        "key": "network-traffic.src_port",
+        "object": "nt",
+        "transformer": "ToInteger"
+    },
+    "dstport": {
+        "key": "network-traffic.dst_port",
+        "object": "nt",
+        "transformer": "ToInteger"
+    },
+  "protocol": {
+    "key": "network-traffic.protocols",
+    "object": "nt",
+    "transformer": "ToLowercaseArray"
+  },
+  "domain-name": {
+    "fields": {
+      "value": ["url.domain"]
+    }
+  },
+  "user": {
+    "key": "user-account.user_id"
+  },
+  "file": {
+    "key": "file.name"
+  },
+  "process": {
+    "key": "process.name",
+    "object": "process"
+  },
+  "sha1": {
+    "key": "file.hashes.SHA-1",
+    "object": "file"
+  },
+  "sha256": {
+    "key": "file.hashes.SHA-256",
+    "object": "file"
+  },
+  "md5": {
+    "key": "file.hashes.MD5",
+    "object": "file"
+  },
+  "event": {
+    "key": "x-org-alertflex.event",
+    "object": "x_org_alertflex"
+  },
+  "severity": {
+    "key": "x-org-alertflex.severity",
+    "object": "x_org_alertflex"
+  },
+  "category": {
+    "key": "x-org-alertflex.category",
+    "object": "x_org_alertflex"
+  },
+  "description": {
+    "key": "x-org-alertflex.description",
+    "object": "x_org_alertflex"
+  },
+  "info": {
+    "key": "x-org-alertflex.info",
+    "object": "x_org_alertflex"
+  },
+  "agent": {
+    "key": "x-org-alertflex.agent",
+    "object": "x_org_alertflex"
+  },
+  "source": {
+    "key": "x-org-alertflex.source",
+    "object": "x_org_alertflex"
+  },
+  "type": {
+    "key": "x-org-alertflex.finding_type",
+    "object": "x_org_alertflex"
+  },
+  "node": {
+    "key": "x-org-alertflex.node",
+    "object": "x_org_alertflex"
+  }
+}

--- a/stix_shifter_modules/azure_sentinel/stix_translation/json/stix_2_1/from_stix_map.json
+++ b/stix_shifter_modules/azure_sentinel/stix_translation/json/stix_2_1/from_stix_map.json
@@ -110,7 +110,7 @@
       "hostStates.os": ["hostStates.os"],
       "hostStates.privateIpAddress": ["hostStates.privateIpAddress"],
       "hostStates.riskScore": ["hostStates.riskScore"],
-      "id": ["id"],
+      "alert_id": ["id"],
       "incidentIds": ["incidentIds"],
       "lastModifiedDateTime": ["lastModifiedDateTime"],
       "malwareStates.category": ["malwareStates.category"],

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/from_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/from_stix_map.json
@@ -29,7 +29,7 @@
   },
   "x-ecs-network": {
     "fields": {
-      "inner.vlan.id": ["network.inner.vlan.id"],
+      "inner.vlan.vlan_id": ["network.inner.vlan.id"],
       "inner.vlan.name": ["network.inner.vlan.name"],
       "name": ["network.name"],
       "application": ["network.application"],
@@ -102,7 +102,7 @@
       "domain": ["user.domain"],
       "full_name": ["user.full_name"],
       "hash": ["user.hash"],
-      "id": ["user.id"],
+      "user_id": ["user.id"],
       "group_domain": ["user.group.domain"],
       "group_id": ["user.group.id"],
       "group_name": ["user.group.name"]
@@ -127,7 +127,7 @@
       "executable": ["process.executable"],
       "entity_id": ["process.entity_id"],
       "exit_code": ["process.exit_code"],
-      "thread.id": ["process.thread.id"],
+      "thread.thread_id": ["process.thread.id"],
       "thread.name": ["process.thread.name"],
       "title": ["process.title"],
       "uptime": ["process.uptime"],
@@ -137,7 +137,7 @@
       "parent.entity_id": ["process.parent.entity_id"],
       "parent.exit_code": ["process.parent.exit_code"],
       "parent.pgid": ["process.parent.pgid"],
-      "parent.thread.id": ["process.parent.thread.id"],
+      "parent.thread.thread_id": ["process.parent.thread.id"],
       "parent.thread.name": ["process.parent.thread.name"],
       "parent.title": ["process.parent.title"],
       "parent.uptime": ["process.parent.uptime"],
@@ -193,7 +193,7 @@
   "x-oca-event": {
     "fields": {
       "action": ["event.action"],
-      "id": ["event.id"],
+      "event_id": ["event.id"],
       "category": ["event.category"],
       "code": ["event.code"],
       "created": ["event.created"],
@@ -233,9 +233,9 @@
   },
   "x-ecs-cloud": {
     "fields": {
-      "account.id": ["cloud.account.id"],
+      "account.account_id": ["cloud.account.id"],
       "availability_zone": ["cloud.availability_zone"],
-      "instance.id": ["cloud.instance.id"],
+      "instance.instance_id": ["cloud.instance.id"],
       "instance.name": ["cloud.instance.name"],
       "machine.type": ["cloud.machine.type"],
       "provider": ["cloud.provider"],
@@ -244,7 +244,7 @@
   },
   "x-ecs-container": {
     "fields": {
-      "id": ["container.id"],
+      "container_id": ["container.id"],
       "image.name": ["container.image.name"],
       "image.tag": ["container.image.tag"],
       "labels": ["container.labels"],
@@ -276,7 +276,7 @@
       "answers_ttl": ["dns.answers.ttl"],
       "answers_type": ["dns.answers.type"],
       "header_flags": ["dns.header_flags"],
-      "id": ["dns.id"],
+      "dns_id": ["dns.id"],
       "op_code": ["dns.op_code"],
       "question_class": ["dns.question.class"],
       "question_name": ["dns.question.name"],
@@ -297,7 +297,7 @@
   "x-ecs-error": {
     "fields": {
       "code": ["error.code"],
-      "id": ["error.id"],
+      "error_id": ["error.id"],
       "message": ["error.message"],
       "stack_trace": ["error.stack_trace"],
       "type": ["error.type"]
@@ -306,7 +306,7 @@
   "x-ecs-group": {
     "fields": {
       "domain": ["group.domain"],
-      "id": ["group.id"],
+      "group_id": ["group.id"],
       "name": ["group.name"]
     }
   },
@@ -315,7 +315,7 @@
       "architecture": ["host.architecture"],
       "domain": ["host.domain"],
       "hostname": ["host.hostname"],
-      "id": ["host.id"],
+      "asset_id": ["host.id"],
       "ip": ["host.ip"],
       "mac": ["host.mac"],
       "name": ["host.name"],
@@ -381,7 +381,7 @@
   },
   "x-ecs-organization": {
     "fields": {
-      "id": ["organization.id"],
+      "organization_id": ["organization.id"],
       "name": ["organization.name"]
     }
   },
@@ -406,7 +406,7 @@
       "author": ["rule.author"],
       "category": ["rule.category"],
       "description": ["rule.description"],
-      "id": ["rule.id"],
+      "rule_id": ["rule.id"],
       "license": ["rule.license"],
       "name": ["rule.name"],
       "reference": ["rule.reference"],
@@ -417,7 +417,7 @@
   },
   "x-ecs-service": {
     "fields": {
-      "id": ["service.id"],
+      "service_id": ["service.id"],
       "name": ["service.name"],
       "state": ["service.state"],
       "type": ["service.type"],
@@ -437,12 +437,12 @@
   },
   "x-ecs-trace": {
     "fields": {
-      "id": ["trace.id"]
+      "trace_id": ["trace.id"]
     }
   },
   "x-ecs-transaction": {
     "fields": {
-      "id": ["transaction.id"]
+      "transaction_id": ["transaction.id"]
     }
   },
   "x-ecs-user-agent": {
@@ -459,7 +459,7 @@
       "classification": ["vulnerability.classification"],
       "description": ["vulnerability.description"],
       "enumeration": ["vulnerability.enumeration"],
-      "id": ["vulnerability.id"],
+      "vulnerability_id": ["vulnerability.id"],
       "reference": ["vulnerability.reference"],
       "report_id": ["vulnerability.report_id"],
       "severity": ["vulnerability.severity"],

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
@@ -632,7 +632,7 @@
       "object": "event"
     },
     "id": {
-      "key": "x-oca-event.id",
+      "key": "x-oca-event.event_id",
       "object": "event"
     },
     "category": {
@@ -1036,7 +1036,7 @@
     },
     "id": [
       {
-        "key": "x-ecs-user.id",
+        "key": "x-ecs-user.user_id",
         "object": "x_user"
       },
       {
@@ -1124,7 +1124,7 @@
   },
   "container": {
     "id": {
-      "key": "x-ecs-container.id",
+      "key": "x-ecs-container.container_id",
       "object": "container"
     },
     "image": {
@@ -1325,7 +1325,7 @@
       "object": "error"
     },
     "id": {
-      "key": "x-ecs-error.id",
+      "key": "x-ecs-error.error_id",
       "object": "error"
     },
     "message": {
@@ -1498,7 +1498,7 @@
       "object": "group"
     },
     "id": {
-      "key": "x-ecs-group.id",
+      "key": "x-ecs-group.group_id",
       "object": "group"
     },
     "name": {
@@ -1527,7 +1527,7 @@
       }
     ],
     "id": {
-      "key": "x-oca-asset.id",
+      "key": "x-oca-asset.asset_id",
       "object": "host"
     },
     "ip": [
@@ -1925,7 +1925,7 @@
   },
   "organization": {
     "id": {
-      "key": "x-ecs-organization.id",
+      "key": "x-ecs-organization.organization_id",
       "object": "organization"
     },
     "name": {
@@ -2018,7 +2018,7 @@
       "object": "rule"
     },
     "id": {
-      "key": "x-ecs-rule.id",
+      "key": "x-ecs-rule.rule_id",
       "object": "rule"
     },
     "license": {
@@ -2048,7 +2048,7 @@
   },
   "service": {
     "id": {
-      "key": "x-ecs-service.id",
+      "key": "x-ecs-service.service_id",
       "object": "service"
     },
     "name": {
@@ -2236,13 +2236,13 @@
   },
   "trace": {
     "id": {
-      "key": "x-ecs-trace.id",
+      "key": "x-ecs-trace.trace_id",
       "object": "trace"
     }
   },
   "transaction": {
     "id": {
-      "key": "x-ecs-transaction.id",
+      "key": "x-ecs-transaction.transaction_id",
       "object": "transaction"
     }
   },
@@ -2284,7 +2284,7 @@
       "object": "vulnerability"
     },
     "id": {
-      "key": "x-ecs-vulnerability.id",
+      "key": "x-ecs-vulnerability.vulnerability_id",
       "object": "vulnerability"
     },
     "reference": {


### PR DESCRIPTION
Some mapped properties were set to `id` but this is reserved for STIX 2.1 cyber observable objects. Fix this for 2.1 mappings.