### PR TITLE
remove process_user field mapping from windows-registry-key stix object

### DIFF
--- a/stix_shifter_modules/splunk/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/splunk/stix_translation/json/to_stix_map.json
@@ -185,11 +185,6 @@
   ],
   "process_user": [
     {
-      "key": "windows-registry-key.creator_user_ref",
-      "object": "windows-registry-key",
-      "references": "authentication"
-    },
-    {
       "key": "process.creator_user_ref",
       "object": "process",
       "references": "authentication"


### PR DESCRIPTION
splunk process_user field shouldn't be in windows-registry-key unless the event is a key creation event.