### PR TITLE
fix two deprecation warnings

### DIFF
--- a/stix_shifter_utils/stix_transmission/utils/RestApiClient.py
+++ b/stix_shifter_utils/stix_transmission/utils/RestApiClient.py
@@ -23,7 +23,7 @@ class InterruptableThread(threading.Thread):
         self._args = args
         self._kwargs = kwargs
         self._result = None
-        self.setDaemon(True)
+        self.daemon = True
 
     def run(self):
         self._result = self._func(*self._args, **self._kwargs)
@@ -104,7 +104,7 @@ class RestApiClient:
             try:
                 session = requests.Session()
                 retry_strategy = Retry(total=self.retry_max, backoff_factor=0, status_forcelist=[429, 500, 502, 503, 504],
-                                       method_whitelist=["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
+                                       allowed_methods=["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
                 session.mount("https://", TimeoutHTTPAdapter(max_retries=retry_strategy))
 
                 if self.sni is not None:


### PR DESCRIPTION
Get two warning when testing Kestrel:

```
tests/test_command_get.py::test_get_single_stixshifter_stix_bundle
tests/test_command_get.py::test_get_single_stixshifter_stix_bundle
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
  /kestrel-dev/lib64/python3.10/site-packages/stix_shifter_utils/stix_transmission/utils/RestApiClient.py:106: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
    retry_strategy = Retry(total=self.retry_max, backoff_factor=0, status_forcelist=[429, 500, 502, 503, 504],

tests/test_command_get.py::test_get_single_stixshifter_stix_bundle
tests/test_command_get.py::test_get_single_stixshifter_stix_bundle
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
tests/test_command_get.py::test_get_multiple_stixshifter_stix_bundles
  /kestrel-dev/lib64/python3.10/site-packages/stix_shifter_utils/stix_transmission/utils/RestApiClient.py:26: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
    self.setDaemon(True)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```