### PR TITLE
splunk: fix translation of IN, LIKE, and MATCHES [#789]

### DIFF
--- a/stix_shifter_modules/splunk/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/splunk/stix_translation/query_constructor.py
@@ -163,12 +163,21 @@ class _ObservationExpressionTranslator:
 
     def _build_comparison(self, expression, object_scoping, field_mapping):
         comparator = self._lookup_comparison_operator(self, expression.comparator)
+
         if isinstance(comparator, str):
-            splunk_comparison = self._maybe_negate("{} {} {}".format(
-                field_mapping,
-                comparator,
-                encoders.simple(expression.value)
-            ), expression.negated)
+            if comparator == "encoders.like":
+                comparison = encoders.like(field_mapping, expression.value)
+            elif comparator == "encoders.set":
+                comparison = encoders.set(field_mapping, expression.value)
+            elif comparator == "encoders.matches":
+                comparison = encoders.matches(field_mapping, expression.value)
+            else:
+                comparison = "{} {} {}".format(
+                    field_mapping,
+                    comparator,
+                    encoders.simple(expression.value)
+                )
+            splunk_comparison = self._maybe_negate(comparison, expression.negated)
 
             if isinstance(self.dmm, CarBaseQueryTranslator):
                 return "({} AND {})".format(object_scoping, splunk_comparison)

--- a/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -288,5 +288,12 @@ class TestStixToSpl(unittest.TestCase, object):
         expected_queries = f'search ((source = "") AND ((signature_id = "") OR (signature = ""))) earliest="-5minutes" | head 10000 | fields {fields}'
         _test_query_assertions(result_query, expected_queries)
 
+    def test_ipv4_query_in_operator(self):
+        stix_pattern = "[ipv4-addr:value IN ('192.168.122.83', '192.168.122.84')]"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = f'search ((src_ip IN ("192.168.122.83", "192.168.122.84")) OR (dest_ip IN ("192.168.122.83", "192.168.122.84"))) earliest="-5minutes" | head 10000 | fields {fields}'
+        _test_query_assertions(query, queries)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #789 