### PR TITLE
splunk: fix incorrect dst_ref.value mapping [#919]

### DIFF
--- a/stix_shifter_modules/splunk/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/splunk/stix_translation/json/from_stix_map.json
@@ -125,7 +125,7 @@
         "fields": {
             "src_ref.value": "src",
             "src_port": "src_port",
-            "dst_ref.value": "src",
+            "dst_ref.value": "dest",
             "dst_port": "dest_port",
             "protocols[*]": "protocol",
             "start": "earliest",

--- a/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -152,6 +152,12 @@ class TestStixToSpl(unittest.TestCase, object):
         queries = f'search index=_audit ss_name="sample_alert" action=alert_fired earliest="-5minutes" | head 10000 | fields {fields}'
         _test_query_assertions(query, queries)
 
+    def test_dst_ref_queries(self):
+        stix_pattern = "[network-traffic:dst_ref.value = '192.168.122.83']"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = f'search (dest = "192.168.122.83") earliest="-5minutes" | head 10000 | fields {fields}'
+        _test_query_assertions(query, queries)
+
     def test_port_queries(self):
         stix_pattern = "[network-traffic:src_port = 12345 OR network-traffic:dst_port = 23456]"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)


### PR DESCRIPTION
Closes #919 