### PR TITLE
Fallback to random UUID if no id contributing properties in the result

### DIFF
--- a/stix_shifter_modules/mysql/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/mysql/stix_translation/json/stix_2_1/to_stix_map.json
@@ -52,6 +52,12 @@
       "object": "useraccount"
     }
   ],
+  "displayname": [
+    {
+      "key": "user-account.display_name",
+      "object": "useraccount"
+    }
+  ],
   "filename": [
     {
       "key": "file.name",

--- a/stix_shifter_modules/mysql/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/mysql/stix_translation/json/to_stix_map.json
@@ -52,6 +52,12 @@
       "object": "useraccount"
     }
   ],
+  "displayname": [
+    {
+      "key": "user-account.display_name",
+      "object": "useraccount"
+    }
+  ],
   "filename": [
     {
       "key": "file.name",

--- a/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix_translator.py
+++ b/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix_translator.py
@@ -354,7 +354,7 @@ class DataSourceObjToStixObj:
             if cybox_properties:
                 unique_id = cybox_type + "--" + str(uuid.uuid5(namespace=uuid.UUID(UUID5_NAMESPACE), name=json.dumps(cybox_properties)))
 
-        else: # STIX process or custom object used UUID4 for identifier
+        if not unique_id: # STIX process or custom object used UUID4 for identifier
             unique_id = "{}--{}".format(cybox_type, str(uuid.uuid4()))
 
         return unique_id

--- a/tests/stix_translation/test_results_translation.py
+++ b/tests/stix_translation/test_results_translation.py
@@ -20,7 +20,7 @@ DATA = {
             "source_ipaddr": "0.0.0.0", 
             "dest_ipaddr": "255.255.255.1", 
             "url": "https://example.com", 
-            "username": "someuserid2018", 
+            "displayname": "someuserid2018",
             "protocol": 'tcp',
             "source_port": 3000, 
             "dest_port": 2000, 
@@ -44,7 +44,6 @@ CYBOX_ID = {
             "source-ipv4-addr": "ipv4-addr--0b6a89e3-e345-51b7-a8ee-aaff7ebf2df5", 
             "dest-ipv4-addr": "ipv4-addr--cb8e152d-60f0-596a-81e4-a22cc4a7f063", 
             "url": "url--8265905f-c609-52e3-ae52-6681bcd6086d", 
-            "user-account": "user-account--3cd7ffc9-89f7-5b58-948c-117ec9b3e22a", 
             "network-traffic": "network-traffic--2ec70516-29b5-59f3-9743-3b93e97db6d8",
             "file": "file--243f1b5f-0391-501c-bed0-17e9f204f1d2",
             "directory": "directory--9ce39e76-d59e-5db2-8f0e-2001f689ea9d"
@@ -159,7 +158,7 @@ class TestTransform(object):
         # user-account
         stix_object = TestTransform.get_first_of_type(objects.values(), 'user-account')
         assert  stix_object, 'user-account object type not found'
-        assert  "user_id" in stix_object and stix_object['user_id'] == DATA['username']
+        assert "display_name" in stix_object
 
         # file
         file_object = TestTransform.get_first_of_type(objects.values(), 'file')
@@ -244,11 +243,11 @@ class TestTransform(object):
         assert "value" in url_object and url_object['value'] == DATA['url']
         assert "id" in url_object and str(url_object['id']) == CYBOX_ID["url"]
 
-        # user-account
+        # user-account with only properties that are not ID contributing
         user_account_object = TestTransform.get_first_cybox_of_type_stix_2_1(result_bundle_objects, 'user-account')
-        assert  user_account_object, 'user-account object type not found'
-        assert  "user_id" in user_account_object and user_account_object['user_id'] == DATA['username']
-        assert "id" in user_account_object and str(user_account_object['id']) == CYBOX_ID["user-account"]
+        assert user_account_object, 'user-account object type not found'
+        assert "display_name" in user_account_object
+        assert "id" in user_account_object
 
         # file
         file_object = TestTransform.get_first_cybox_of_type_stix_2_1(result_bundle_objects, 'file')
@@ -278,6 +277,7 @@ class TestTransform(object):
         assert "modified" not in directory_object
         assert "atime" in directory_object and directory_object['atime'] == TIMESTAMP
         assert "accessed" not in directory_object
+        assert "id" in directory_object
 
         # process
         process_object = TestTransform.get_first_of_type(result_bundle_objects, 'process')


### PR DESCRIPTION
Fallback to random UUID if STIX 2.1 object definition has ID contributing properties but the results have no data for those properties.