### PR TITLE
Removed allowed methods from Retry (passed by default)

### DIFF
--- a/stix_shifter_utils/stix_transmission/utils/RestApiClient.py
+++ b/stix_shifter_utils/stix_transmission/utils/RestApiClient.py
@@ -103,8 +103,7 @@ class RestApiClient:
                 url = 'https://' + self.server_ip + '/' + endpoint
             try:
                 session = requests.Session()
-                retry_strategy = Retry(total=self.retry_max, backoff_factor=0, status_forcelist=[429, 500, 502, 503, 504],
-                                       allowed_methods=["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
+                retry_strategy = Retry(total=self.retry_max, backoff_factor=0, status_forcelist=[429, 500, 502, 503, 504])
                 session.mount("https://", TimeoutHTTPAdapter(max_retries=retry_strategy))
 
                 if self.sni is not None:


### PR DESCRIPTION
allowed methods parameter is causing an issue for the Infoblox module.
The methods passed are default allowed methods specified in the Retry module.