### PR TITLE
Downgrade boto3 version to 1.21.21

### DIFF
--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -1,7 +1,7 @@
 adal==1.2.7
 antlr4-python3-runtime==4.8
-boto3
-flask==2.1.2
+boto3==1.21.21
+flask==2.0.3
 pyOpenSSL==21.0.0
 flatten_json==0.1.13
 python-dateutil==2.8.2

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -1,7 +1,7 @@
 adal==1.2.7
 antlr4-python3-runtime==4.8
-boto3==1.22.10
-flask==2.0.3
+boto3
+flask==2.1.2
 pyOpenSSL==21.0.0
 flatten_json==0.1.13
 python-dateutil==2.8.2


### PR DESCRIPTION
This is to address compatibility issues with [aiobotocore](https://github.com/aio-libs/aiobotocore)