### PR TITLE
Process unique ID

### DIFF
--- a/adapter-guide/connectors/elastic_ecs_supported_stix.md
+++ b/adapter-guide/connectors/elastic_ecs_supported_stix.md
@@ -1,4 +1,4 @@
-##### Updated on 06/01/22
+##### Updated on 07/21/22
 ## Elasticsearch ECS
 ### Supported STIX Operators
 | STIX Operator | Data Source Operator |
@@ -94,6 +94,7 @@
 | process | parent_ref | ppid |
 | process | command_line | command_line |
 | process | binary_ref | executable |
+| process | x_unique_id | entity_id |
 | process | parent_ref | name |
 | process | parent_ref | pid |
 | process | creator_user_ref | name |
@@ -287,11 +288,9 @@
 | x-ecs-process | pe_product | product |
 | x-ecs-process | args | args |
 | x-ecs-process | args_count | args_count |
-| x-ecs-process | entity_id | entity_id |
 | x-ecs-process | exit_code | exit_code |
 | x-ecs-process | parent_args | args |
 | x-ecs-process | parent_args_count | args_count |
-| x-ecs-process | parent_entity_id | entity_id |
 | x-ecs-process | parent_exit_code | exit_code |
 | x-ecs-process | parent_pgid | pgid |
 | x-ecs-process | parent_ppid | ppid |

--- a/adapter-guide/connectors/qradar_supported_stix.md
+++ b/adapter-guide/connectors/qradar_supported_stix.md
@@ -138,14 +138,6 @@
 | x-ibm-finding | name | "CRE Name" |
 | x-ibm-finding | description | "CRE Description" |
 | <br> | | |
-| x-ibm-windows | targetimage | TargetImage |
-| x-ibm-windows | granted_access | GrantedAccess |
-| x-ibm-windows | call_trace | CallTrace |
-| x-ibm-windows | pipe_name | PipeName |
-| x-ibm-windows | start_module | StartModule |
-| x-ibm-windows | start_function | StartFunction |
-| x-ibm-windows | signed | Signed |
-| <br> | | |
 | x-oca-asset | ip_refs | identityip |
 | x-oca-asset | hostname | identityhostname |
 | x-oca-asset | ip_refs | sourceaddress |

--- a/adapter-guide/connectors/qradar_supported_stix.md
+++ b/adapter-guide/connectors/qradar_supported_stix.md
@@ -1,4 +1,4 @@
-##### Updated on 06/01/22
+##### Updated on 07/26/22
 ## IBM QRadar
 ### Supported STIX Operators
 | STIX Operator | Data Source Operator |
@@ -109,6 +109,7 @@
 | process | parent_ref | "Parent Process ID" |
 | process | binary_ref | TargetImage |
 | process | extensions.windows-service-ext.service_dll_refs | ServiceFileName |
+| process | x_unique_id | "Process Guid" |
 | <br> | | |
 | software | name | applicationname |
 | <br> | | |
@@ -136,6 +137,14 @@
 | x-ibm-finding | rule_names | rulename(creeventlist) |
 | x-ibm-finding | name | "CRE Name" |
 | x-ibm-finding | description | "CRE Description" |
+| <br> | | |
+| x-ibm-windows | targetimage | TargetImage |
+| x-ibm-windows | granted_access | GrantedAccess |
+| x-ibm-windows | call_trace | CallTrace |
+| x-ibm-windows | pipe_name | PipeName |
+| x-ibm-windows | start_module | StartModule |
+| x-ibm-windows | start_function | StartFunction |
+| x-ibm-windows | signed | Signed |
 | <br> | | |
 | x-oca-asset | ip_refs | identityip |
 | x-oca-asset | hostname | identityhostname |

--- a/adapter-guide/connectors/reaqta_supported_stix.md
+++ b/adapter-guide/connectors/reaqta_supported_stix.md
@@ -1,4 +1,4 @@
-##### Updated on 06/01/22
+##### Updated on 07/27/22
 ## ReaQta
 ### Supported STIX Operators
 | STIX Operator | Data Source Operator |
@@ -54,10 +54,10 @@
 | network-traffic | dst_ref | remoteAddrV6 |
 | network-traffic | dst_port | remotePort |
 | <br> | | |
-| process | extensions.x-process-ext.process_uid | id |
+| process | x_unique_id | id |
 | process | extensions.x-reaqta-process.logon_id | logonId |
 | process | extensions.x-reaqta-process.no_gui | noGui |
-| process | extensions.x-process-ext.parent_process_uid | parentId |
+| process | x_unique_id | parentId |
 | process | pid | pid |
 | process | pid | ppid |
 | process | parent_ref | ppid |

--- a/adapter-guide/connectors/sentinelone_supported_stix.md
+++ b/adapter-guide/connectors/sentinelone_supported_stix.md
@@ -1,4 +1,4 @@
-##### Updated on 06/01/22
+##### Updated on 07/28/22
 ## SentinelOne
 ### Supported STIX Operators
 | STIX Operator | Data Source Operator |
@@ -98,8 +98,8 @@
 | process | extensions.x-sentinelone-process.story_line_id | tgtProcStorylineId |
 | process | extensions.x-sentinelone-process.integrity_level | srcProcIntegrityLevel |
 | process | extensions.x-sentinelone-process.integrity_level | tgtProcIntegrityLevel |
-| process | extensions.x-sentinelone-process.process_unique_id | srcProcUid |
-| process | extensions.x-sentinelone-process.process_unique_id | tgtProcUid |
+| process | x_unique_id | srcProcUid |
+| process | x_unique_id | tgtProcUid |
 | process | extensions.x-sentinelone-process.signed_status | srcProcSignedStatus |
 | process | extensions.x-sentinelone-process.signed_status | tgtProcSignedStatus |
 | process | extensions.x-sentinelone-process.publisher | srcProcPublisher |
@@ -122,7 +122,7 @@
 | process | extensions.x-sentinelone-process.active_content_hash | tgtProcActiveContentHash |
 | process | extensions.x-sentinelone-process.active_content_signed_status | srcProcActiveContentSignedStatus |
 | process | extensions.x-sentinelone-process.active_content_signed_status | tgtProcActiveContentSignedStatus |
-| process | extensions.x-sentinelone-process.process_unique_id | srcProcParentUid |
+| process | x_unique_id | srcProcParentUid |
 | <br> | | |
 | url | value | url |
 | <br> | | |

--- a/stix_shifter_modules/cbcloud/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/cbcloud/stix_translation/json/from_stix_map.json
@@ -32,7 +32,8 @@
       "parent_ref.name": ["parent_name"],
       "parent_ref.binary_ref.name": ["parent_name"],
       "parent_ref.binary_ref.hashes.MD5": ["parent_hash"],
-      "parent_ref.binary_ref.hashes.'SHA-256'": ["parent_hash"]
+      "parent_ref.binary_ref.hashes.'SHA-256'": ["parent_hash"],
+      "x_unique_id": ["process_guid", "parent_guid"]
     }
   },
   "software": {

--- a/stix_shifter_modules/cbcloud/stix_translation/json/stix_2_1/from_stix_map.json
+++ b/stix_shifter_modules/cbcloud/stix_translation/json/stix_2_1/from_stix_map.json
@@ -31,7 +31,8 @@
       "parent_ref.name": ["parent_name"],
       "parent_ref.image_ref.name": ["parent_name"],
       "parent_ref.image_ref.hashes.MD5": ["parent_hash"],
-      "parent_ref.image_ref.hashes.'SHA-256'": ["parent_hash"]
+      "parent_ref.image_ref.hashes.'SHA-256'": ["parent_hash"],
+      "x_unique_id": ["process_guid", "parent_guid"]
     }
   },
   "software": {

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/from_stix_map.json
@@ -118,7 +118,8 @@
       "parent_ref.pid": ["process.ppid", "process.parent.ppid"],
       "parent_ref.name": ["process.parent.name"],
       "binary_ref.name": ["process.executable", "process.parent.executable"],
-      "x_ttp_tags": ["tags"]
+      "x_ttp_tags": ["tags"],
+      "x_unique_id": ["process.entity_id", "process.parent.entity_id"]
     }
   },
   "x-ecs-process": {
@@ -126,7 +127,6 @@
       "args": ["process.args"],
       "args_count": ["process.args_count"],
       "executable": ["process.executable"],
-      "entity_id": ["process.entity_id"],
       "exit_code": ["process.exit_code"],
       "thread.id": ["process.thread.id"],
       "thread.name": ["process.thread.name"],
@@ -135,7 +135,6 @@
       "working_directory": ["process.working_directory"],
       "parent.args": ["process.parent.args"],
       "parent.args_count": ["process.parent.args_count"],
-      "parent.entity_id": ["process.parent.entity_id"],
       "parent.exit_code": ["process.parent.exit_code"],
       "parent.pgid": ["process.parent.pgid"],
       "parent.thread.id": ["process.parent.thread.id"],

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/from_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/from_stix_map.json
@@ -117,7 +117,8 @@
       "parent_ref.pid": ["process.ppid", "process.parent.ppid"],
       "parent_ref.name": ["process.parent.name"],
       "image_ref.name": ["process.executable", "process.parent.executable"],
-      "x_ttp_tags": ["tags"]
+      "x_ttp_tags": ["tags"],
+      "x_unique_id": ["process.entity_id", "process.parent.entity_id"]
     }
   },
   "x-ecs-process": {
@@ -125,7 +126,6 @@
       "args": ["process.args"],
       "args_count": ["process.args_count"],
       "executable": ["process.executable"],
-      "entity_id": ["process.entity_id"],
       "exit_code": ["process.exit_code"],
       "thread.thread_id": ["process.thread.id"],
       "thread.name": ["process.thread.name"],
@@ -134,7 +134,6 @@
       "working_directory": ["process.working_directory"],
       "parent.args": ["process.parent.args"],
       "parent.args_count": ["process.parent.args_count"],
-      "parent.entity_id": ["process.parent.entity_id"],
       "parent.exit_code": ["process.parent.exit_code"],
       "parent.pgid": ["process.parent.pgid"],
       "parent.thread.thread_id": ["process.parent.thread.id"],

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
@@ -855,8 +855,8 @@
       }
     ],
     "entity_id": {
-      "key": "x-ecs-process.entity_id",
-      "object": "x_process"
+      "key": "process.x_unique_id",
+      "object": "process"
     },
     "exit_code": {
       "key": "x-ecs-process.exit_code",
@@ -876,8 +876,8 @@
         "object": "process_parent"
       },
       "entity_id": {
-        "key": "x-ecs-process.parent_entity_id",
-        "object": "x_process"
+        "key": "process.x_unique_id",
+        "object": "process_parent"
       },
       "exit_code": {
         "key": "x-ecs-process.parent_exit_code",

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -867,8 +867,8 @@
       }
     ],
     "entity_id": {
-      "key": "x-ecs-process.entity_id",
-      "object": "x_process"
+      "key": "process.x_unique_id",
+      "object": "process"
     },
     "exit_code": {
       "key": "x-ecs-process.exit_code",
@@ -888,8 +888,8 @@
         "object": "process_parent"
       },
       "entity_id": {
-        "key": "x-ecs-process.parent_entity_id",
-        "object": "x_process"
+        "key": "process.x_unique_id",
+        "object": "process_parent"
       },
       "exit_code": {
         "key": "x-ecs-process.parent_exit_code",

--- a/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
+++ b/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
@@ -329,7 +329,7 @@ class TestElasticEcsTransform(unittest.TestCase, object):
         proc_object = TestElasticEcsTransform.get_first_of_type(objects.values(), 'process')
         assert (proc_object is not None), 'process object type not found'
         assert (proc_object.keys() ==
-                {'type', 'pid', 'name', 'created', 'opened_connection_refs', 'creator_user_ref', 'binary_ref', 'parent_ref'})
+                {'type', 'pid', 'name', 'created', 'opened_connection_refs', 'creator_user_ref', 'binary_ref', 'parent_ref', 'x_unique_id'})
         assert (proc_object['type'] == 'process')
         assert (proc_object['pid'] == 609)
         assert (proc_object['created'] == '2019-04-10T11:33:57.571Z')

--- a/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
@@ -62,6 +62,7 @@
     "\"Process ID\" as ProcessId",
     "\"Parent Process ID\" as ParentProcessId",
     "hasoffense",
-    "\"Machine ID\" as MachineId"
+    "\"Machine ID\" as MachineId",
+    "\"Process Guid\" as ProcessGuid"
   ]
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/aql_events_fields.json
@@ -62,7 +62,6 @@
     "\"Process ID\" as ProcessId",
     "\"Parent Process ID\" as ParentProcessId",
     "hasoffense",
-    "\"Machine ID\" as MachineId",
-    "\"Process Guid\" as ProcessGuid"
+    "\"Machine ID\" as MachineId"
   ]
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
@@ -101,7 +101,8 @@
       "parent_ref.binary_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
-      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"]
+      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"],
+      "x_unique_id": ["ProcessGuid"]
     }
   },
   "x-oca-event": {

--- a/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
@@ -101,8 +101,7 @@
       "parent_ref.binary_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
-      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"],
-      "x_unique_id": ["ProcessGuid"]
+      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"]
     }
   },
   "x-oca-event": {
@@ -143,15 +142,6 @@
     "fields": {
       "key": ["ObjectName", "RegistryKey"],
       "values[*].name": ["RegistryValueName"]
-    }
-  },
-  "x-ibm-windows": {
-    "fields": {
-      "targetimage": ["TargetImage"],
-      "grantedaccess": ["GrantedAccess"],
-      "calltrace": ["CallTrace"],
-      "sourceimage": ["Image"],
-      "pipename": ["PipeName"]
     }
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/events_from_stix_map.json
@@ -101,7 +101,8 @@
       "parent_ref.binary_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
-      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"]
+      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"],
+      "x_unique_id": ["ProcessGuid"]
     }
   },
   "x-oca-event": {
@@ -142,6 +143,15 @@
     "fields": {
       "key": ["ObjectName", "RegistryKey"],
       "values[*].name": ["RegistryValueName"]
+    }
+  },
+  "x-ibm-windows": {
+    "fields": {
+      "targetimage": ["TargetImage"],
+      "grantedaccess": ["GrantedAccess"],
+      "calltrace": ["CallTrace"],
+      "sourceimage": ["Image"],
+      "pipename": ["PipeName"]
     }
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
@@ -95,13 +95,14 @@
   "process": {
     "fields": {
       "pid": ["ProcessId"],
-      "name": ["ProcessName", "Image", "ParentImage"],
-      "image_ref.name": ["Image"],
-      "image_ref.parent_directory_ref.path": ["Image"],
+      "name": ["ProcessName", "Image", "ParentImage", "TargetImage"],
+      "image_ref.name": ["Image", "TargetImage"],
+      "image_ref.parent_directory_ref.path": ["Image", "TargetImage"],
       "parent_ref.image_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
-      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"]
+      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"],
+      "x_unique_id": ["ProcessGuid"]
     }
   },
   "x-oca-event": {

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
@@ -95,9 +95,9 @@
   "process": {
     "fields": {
       "pid": ["ProcessId"],
-      "name": ["ProcessName", "Image", "ParentImage"],
-      "image_ref.name": ["Image"],
-      "image_ref.parent_directory_ref.path": ["Image"],
+      "name": ["ProcessName", "Image", "ParentImage", "TargetImage"],
+      "image_ref.name": ["Image", "TargetImage"],
+      "image_ref.parent_directory_ref.path": ["Image", "TargetImage"],
       "parent_ref.image_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
@@ -120,11 +120,11 @@
       "process_ref.name": ["ProcessName"],
       "process_ref.pid": ["ProcessId"],
       "parent_process_ref.command_line": ["ParentCommandLine"],
-      "parent_process_ref.image_ref.name": ["ParentImage"],
+      "parent_process_ref.image_ref.name": ["ParentImage", "TargetImage"],
       "domain_ref.value": ["domainname", "UrlHost"],
       "file_ref.name": ["filename"],
-      "host_ref.hostname": ["identityhostname"],
-      "host_ref.ip_refs[*].value": ["identityip"],
+      "host_ref.hostname": ["identityhostname", "MachineId"],
+      "host_ref.ip_refs[*].value": ["identityip", "sourceip"],
       "registry_ref.key": ["ObjectName", "RegistryKey"],
       "user_ref.user_id": ["username"],
       "url_ref.value": ["url"],
@@ -142,15 +142,6 @@
     "fields": {
       "key": ["ObjectName", "RegistryKey"],
       "values[*].name": ["RegistryValueName"]
-    }
-  },
-  "x-ibm-windows": {
-    "fields": {
-      "targetimage": ["TargetImage"],
-      "grantedaccess": ["GrantedAccess"],
-      "calltrace": ["CallTrace"],
-      "sourceimage": ["Image"],
-      "pipename": ["PipeName"]
     }
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
@@ -95,14 +95,13 @@
   "process": {
     "fields": {
       "pid": ["ProcessId"],
-      "name": ["ProcessName", "Image", "ParentImage", "TargetImage"],
-      "image_ref.name": ["Image", "TargetImage"],
-      "image_ref.parent_directory_ref.path": ["Image", "TargetImage"],
+      "name": ["ProcessName", "Image", "ParentImage"],
+      "image_ref.name": ["Image"],
+      "image_ref.parent_directory_ref.path": ["Image"],
       "parent_ref.image_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
-      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"],
-      "x_unique_id": ["ProcessGuid"]
+      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"]
     }
   },
   "x-oca-event": {

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/events_from_stix_map.json
@@ -101,7 +101,8 @@
       "parent_ref.image_ref.name": ["ParentImage"],
       "command_line": ["ProcessCommandLine", "ParentCommandLine"],
       "parent_ref.command_line": ["ParentCommandLine"],
-      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"]
+      "extensions.'windows-service-ext'.service_dll_refs[*].name": ["ServiceFileName"],
+      "x_unique_id": ["ProcessGuid"]
     }
   },
   "x-oca-event": {

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
@@ -491,7 +491,8 @@
       "key": "x-qradar.flow_source",
       "object": "x-qradar"
     }
-  ],
+  ]
+  ,
   "flowinterface": {
     "key": "x-qradar.flow_interface",
     "object": "x-qradar"
@@ -798,32 +799,10 @@
       "references": "winregistry"
     }
   ],
-  "TargetImage": [
-    {
-      "key": "file.name",
-      "object": "file_target_image",
-      "transformer": "ToFileName"
-    },
-    {
-      "key": "directory.path",
-      "object": "directory_target_image",
-      "transformer": "ToDirectoryPath"
-    },
-    {
-      "key": "process.image_ref",
-      "object": "target_process",
-      "references": "file_target_image"
-    },
-    {
-      "key": "file.parent_directory_ref",
-      "object": "file_target_image",
-      "references": "directory_target_image"
-    },
-    {
+  "TargetImage": {
     "key": "x-ibm-windows.targetimage",
     "object": "xwin"
-    }
-  ],
+  },
   "GrantedAccess": {
     "key": "x-ibm-windows.granted_access",
     "object": "xwin"
@@ -898,20 +877,5 @@
   "hasoffense": {
     "key": "x-qradar.has_offense",
     "object": "x-qradar"
-  },
-  "MachineId": [
-    {
-      "key": "x-oca-asset.hostname",
-      "object": "host"
-    },
-    {
-      "key": "x-oca-event.host_ref",
-      "object": "event",
-      "references": "host"
-    }
-  ],
-  "ProcessGuid": {
-    "key": "process.x_unique_id",
-    "object": "process"
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
@@ -491,8 +491,7 @@
       "key": "x-qradar.flow_source",
       "object": "x-qradar"
     }
-  ]
-  ,
+  ],
   "flowinterface": {
     "key": "x-qradar.flow_interface",
     "object": "x-qradar"
@@ -799,10 +798,32 @@
       "references": "winregistry"
     }
   ],
-  "TargetImage": {
+  "TargetImage": [
+    {
+      "key": "file.name",
+      "object": "file_target_image",
+      "transformer": "ToFileName"
+    },
+    {
+      "key": "directory.path",
+      "object": "directory_target_image",
+      "transformer": "ToDirectoryPath"
+    },
+    {
+      "key": "process.image_ref",
+      "object": "target_process",
+      "references": "file_target_image"
+    },
+    {
+      "key": "file.parent_directory_ref",
+      "object": "file_target_image",
+      "references": "directory_target_image"
+    },
+    {
     "key": "x-ibm-windows.targetimage",
     "object": "xwin"
-  },
+    }
+  ],
   "GrantedAccess": {
     "key": "x-ibm-windows.granted_access",
     "object": "xwin"
@@ -877,5 +898,20 @@
   "hasoffense": {
     "key": "x-qradar.has_offense",
     "object": "x-qradar"
+  },
+  "MachineId": [
+    {
+      "key": "x-oca-asset.hostname",
+      "object": "host"
+    },
+    {
+      "key": "x-oca-event.host_ref",
+      "object": "event",
+      "references": "host"
+    }
+  ],
+  "ProcessGuid": {
+    "key": "process.x_unique_id",
+    "object": "process"
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
@@ -491,8 +491,7 @@
       "key": "x-qradar.flow_source",
       "object": "x-qradar"
     }
-  ]
-  ,
+  ],
   "flowinterface": {
     "key": "x-qradar.flow_interface",
     "object": "x-qradar"
@@ -867,5 +866,20 @@
   "hasoffense": {
     "key": "x-qradar.has_offense",
     "object": "x-qradar"
+  },
+  "MachineId": [
+    {
+      "key": "x-oca-asset.hostname",
+      "object": "host"
+    },
+    {
+      "key": "x-oca-event.host_ref",
+      "object": "event",
+      "references": "host"
+    }
+  ],
+  "ProcessGuid": {
+    "key": "process.x_unique_id",
+    "object": "process"
   }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
@@ -799,34 +799,28 @@
       "references": "winregistry"
     }
   ],
-  "TargetImage": {
-    "key": "x-ibm-windows.targetimage",
-    "object": "xwin"
-  },
-  "GrantedAccess": {
-    "key": "x-ibm-windows.granted_access",
-    "object": "xwin"
-  },
-  "CallTrace": {
-    "key": "x-ibm-windows.call_trace",
-    "object": "xwin"
-  },
-  "PipeName": {
-    "key": "x-ibm-windows.pipe_name",
-    "object": "xwin"
-  },
-  "StartModule": {
-    "key": "x-ibm-windows.start_module",
-    "object": "xwin"
-  },
-  "StartFunction": {
-    "key": "x-ibm-windows.start_function",
-    "object": "xwin"
-  },
-  "Signed": {
-    "key": "x-ibm-windows.signed",
-    "object": "xwin"
-  },
+  "TargetImage": [
+    {
+      "key": "file.name",
+      "object": "file_target_image",
+      "transformer": "ToFileName"
+    },
+    {
+      "key": "directory.path",
+      "object": "directory_target_image",
+      "transformer": "ToDirectoryPath"
+    },
+    {
+      "key": "process.binary_ref",
+      "object": "target_process",
+      "references": "file_target_image"
+    },
+    {
+      "key": "file.parent_directory_ref",
+      "object": "file_target_image",
+      "references": "directory_target_image"
+    }
+  ],
   "Message": [
     {
       "key": "artifact.payload_bin",
@@ -846,10 +840,6 @@
   "mime_type_message": {
       "key": "artifact.mime_type",
       "object": "artifact"
-  },
-  "IMPHash": {
-    "key": "x-ibm-windows.imphash",
-    "object": "xwin"
   },
   "ServiceFileName": [
     {

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -888,5 +888,9 @@
       "object": "event",
       "references": "host"
     }
-  ]
+  ],
+  "ProcessGuid": {
+    "key": "process.x_unique_id",
+    "object": "process"
+  }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -829,8 +829,36 @@
       "key": "file.parent_directory_ref",
       "object": "file_target_image",
       "references": "directory_target_image"
+    },
+    {
+      "key": "x-ibm-windows.targetimage",
+      "object": "xwin"
     }
   ],
+  "GrantedAccess": {
+    "key": "x-ibm-windows.granted_access",
+    "object": "xwin"
+  },
+  "CallTrace": {
+    "key": "x-ibm-windows.call_trace",
+    "object": "xwin"
+  },
+  "PipeName": {
+    "key": "x-ibm-windows.pipe_name",
+    "object": "xwin"
+  },
+  "StartModule": {
+    "key": "x-ibm-windows.start_module",
+    "object": "xwin"
+  },
+  "StartFunction": {
+    "key": "x-ibm-windows.start_function",
+    "object": "xwin"
+  },
+  "Signed": {
+    "key": "x-ibm-windows.signed",
+    "object": "xwin"
+  },
   "Message": [
     {
       "key": "artifact.payload_bin",
@@ -888,5 +916,9 @@
       "object": "event",
       "references": "host"
     }
-  ]
+  ],
+  "ProcessGuid": {
+    "key": "process.x_unique_id",
+    "object": "process"
+  }
 }

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -829,36 +829,8 @@
       "key": "file.parent_directory_ref",
       "object": "file_target_image",
       "references": "directory_target_image"
-    },
-    {
-      "key": "x-ibm-windows.targetimage",
-      "object": "xwin"
     }
   ],
-  "GrantedAccess": {
-    "key": "x-ibm-windows.granted_access",
-    "object": "xwin"
-  },
-  "CallTrace": {
-    "key": "x-ibm-windows.call_trace",
-    "object": "xwin"
-  },
-  "PipeName": {
-    "key": "x-ibm-windows.pipe_name",
-    "object": "xwin"
-  },
-  "StartModule": {
-    "key": "x-ibm-windows.start_module",
-    "object": "xwin"
-  },
-  "StartFunction": {
-    "key": "x-ibm-windows.start_function",
-    "object": "xwin"
-  },
-  "Signed": {
-    "key": "x-ibm-windows.signed",
-    "object": "xwin"
-  },
   "Message": [
     {
       "key": "artifact.payload_bin",
@@ -916,9 +888,5 @@
       "object": "event",
       "references": "host"
     }
-  ],
-  "ProcessGuid": {
-    "key": "process.x_unique_id",
-    "object": "process"
-  }
+  ]
 }

--- a/stix_shifter_modules/reaqta/README.md
+++ b/stix_shifter_modules/reaqta/README.md
@@ -96,7 +96,7 @@ python main.py translate reaqta results '{"type":"identity","id":"identity--f431
 ```
 {
     "type": "bundle",
-    "id": "bundle--4cec3200-a574-43fb-8720-ddf81d93929b",
+    "id": "bundle--bb93d310-7f24-4c02-8830-b1a34413cf67",
     "objects": [
         {
             "type": "identity",
@@ -107,55 +107,66 @@ python main.py translate reaqta results '{"type":"identity","id":"identity--f431
             "modified": "2022-04-07T20:35:41.042Z"
         },
         {
-            "id": "observed-data--400d3905-a4fd-46f3-888d-804283a973b6",
+            "id": "observed-data--85159562-3104-41ea-b032-757fdcb7b88b",
             "type": "observed-data",
             "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-            "created": "2022-04-19T20:21:52.930Z",
-            "modified": "2022-04-19T20:21:52.930Z",
+            "created": "2022-07-28T16:31:51.951Z",
+            "modified": "2022-07-28T16:31:51.951Z",
             "objects": {
                 "0": {
                     "type": "x-oca-event",
                     "code": 847102109500309505,
-                    "file_ref": "4",
-                    "user_ref": "5",
-                    "process_ref": "2",
-                    "parent_process_ref": "6",
-                    "network_ref": "8",
+                    "file_ref": "6",
+                    "user_ref": "7",
+                    "process_ref": "3",
+                    "parent_process_ref": "4",
+                    "network_ref": "9",
+                    "category": "8",
+                    "action": "Network Connection Established",
                     "created": "2022-03-29T14:41:21.301Z"
                 },
                 "1": {
-                    "type": "x-reaqta-event",
-                    "endpoint_id": "842028663686823936",
-                    "local_id": "847101972854081537"
+                    "type": "x-oca-asset",
+                    "host_id": "842028663686823936",
+                    "ip_refs": [
+                        "10"
+                    ]
                 },
                 "2": {
+                    "type": "x-reaqta-event",
+                    "local_id": "847101972854081537"
+                },
+                "3": {
                     "type": "process",
+                    "x_unique_id": "842028663686823936:2222:1648564483636",
+                    "binary_ref": "6",
+                    "creator_user_ref": "7",
+                    "pid": 2222,
+                    "created": "2022-03-29T14:34:43.636Z",
+                    "parent_ref": "4",
                     "extensions": {
+                        "windows-process-ext": {
+                            "owner_sid": "S-1-1-11-00000000-1111111-222222222-9999"
+                        },
                         "x-reaqta-process": {
-                            "process_id": "842028663686823936:2222:1648564483636",
-                            "parent_process_id": "842028663686823936:1111:1648485432579",
-                            "process_endpoint_id": "842028663686823936",
                             "privilege_level": "MEDIUM",
                             "no_gui": false,
                             "logon_id": "0xxx1s1"
-                        },
-                        "windows-process-ext": {
-                            "owner_sid": "S-1-1-11-00000000-1111111-222222222-9999"
                         }
-                    },
-                    "binary_ref": "4",
-                    "creator_user_ref": "5",
-                    "pid": 2222,
-                    "created": "2022-03-29T14:34:43.636Z",
-                    "parent_ref": "6"
+                    }
                 },
-                "3": {
+                "4": {
+                    "type": "process",
+                    "x_unique_id": "842028663686823936:1111:1648485432579",
+                    "pid": 1111
+                },
+                "5": {
                     "type": "directory",
                     "path": "c:\\users\\reaqta\\downloads"
                 },
-                "4": {
+                "6": {
                     "type": "file",
-                    "parent_directory_ref": "3",
+                    "parent_directory_ref": "5",
                     "name": "abcd.exe",
                     "hashes": {
                         "MD5": "d05807b758e56634abfdb7cd62798765",
@@ -170,15 +181,11 @@ python main.py translate reaqta results '{"type":"identity","id":"identity--f431
                         }
                     }
                 },
-                "5": {
+                "7": {
                     "type": "user-account",
                     "user_id": "DESKTOP-TEST\\ReaQta-test"
                 },
-                "6": {
-                    "type": "process",
-                    "pid": 1111
-                },
-                "7": {
+                "8": {
                     "type": "x-ibm-finding",
                     "extensions": {
                         "x-reaqta-alert": {
@@ -186,12 +193,10 @@ python main.py translate reaqta results '{"type":"identity","id":"identity--f431
                             "triggered_incidents": []
                         }
                     },
-                    "src_ip_ref": "9",
-                    "dst_ip_ref": "11",
-                    "finding_type": "8",
-                    "name": "Network Connection Established"
+                    "src_ip_ref": "10",
+                    "dst_ip_ref": "11"
                 },
-                "8": {
+                "9": {
                     "type": "network-traffic",
                     "extensions": {
                         "x-reaqta-network": {
@@ -199,12 +204,15 @@ python main.py translate reaqta results '{"type":"identity","id":"identity--f431
                             "outbound": true
                         }
                     },
+                    "protocols": [
+                        "tcp"
+                    ],
                     "src_port": 443,
                     "dst_port": 8443,
-                    "src_ref": "9",
+                    "src_ref": "10",
                     "dst_ref": "11"
                 },
-                "9": {
+                "10": {
                     "type": "ipv4-addr",
                     "value": "192.168.1.2"
                 },

--- a/stix_shifter_modules/reaqta/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/reaqta/stix_translation/json/stix_2_1/to_stix_map.json
@@ -50,7 +50,7 @@
         "object": "asset"
       },
       "id": {
-        "key": "process.extensions.x-process-ext.process_uid",
+        "key": "process.x_unique_id",
         "object": "process"
       },
       "logonId": {
@@ -62,7 +62,7 @@
         "object": "process"
       },
       "parentId": {
-        "key": "process.extensions.x-process-ext.parent_process_uid",
+        "key": "process.x_unique_id",
         "object": "parent_process"
       },
       "pid": [
@@ -211,7 +211,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "accessorProcess_process"
         },
         "logonId": {
@@ -223,7 +223,7 @@
           "object": "accessorProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "accessorProcess_parent_process"
         },
         "pid": [
@@ -379,7 +379,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "allocatorProc_process"
         },
         "logonId": {
@@ -391,7 +391,7 @@
           "object": "allocatorProc_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "allocatorProc_parent_process"
         },
         "pid": [
@@ -581,7 +581,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "childProcess_process"
         },
         "logonId": {
@@ -593,7 +593,7 @@
           "object": "childProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "childProcess_parent_process"
         },
         "pid": [
@@ -842,7 +842,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "engineProcess_process"
         },
         "logonId": {
@@ -854,7 +854,7 @@
           "object": "engineProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "engineProcess_parent_process"
         },
         "pid": [
@@ -1649,7 +1649,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "serviceProcess_process"
         },
         "logonId": {
@@ -1661,7 +1661,7 @@
           "object": "serviceProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "serviceProcess_parent_process"
         },
         "pid": [
@@ -1837,7 +1837,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "targetProcess_process"
         },
         "logonId": {
@@ -1849,7 +1849,7 @@
           "object": "targetProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "targetProcess_parent_process"
         },
         "pid": [

--- a/stix_shifter_modules/reaqta/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/reaqta/stix_translation/json/to_stix_map.json
@@ -50,7 +50,7 @@
         "object": "asset"
       },
       "id": {
-        "key": "process.extensions.x-process-ext.process_uid",
+        "key": "process.x_unique_id",
         "object": "process"
       },
       "logonId": {
@@ -62,7 +62,7 @@
         "object": "process"
       },
       "parentId": {
-        "key": "process.extensions.x-process-ext.parent_process_uid",
+        "key": "process.x_unique_id",
         "object": "parent_process"
       },
       "pid": [
@@ -211,7 +211,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "accessorProcess_process"
         },
         "logonId": {
@@ -223,7 +223,7 @@
           "object": "accessorProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "accessorProcess_parent_process"
         },
         "pid": [
@@ -379,7 +379,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "allocatorProc_process"
         },
         "logonId": {
@@ -391,7 +391,7 @@
           "object": "allocatorProc_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "allocatorProc_parent_process"
         },
         "pid": [
@@ -581,7 +581,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "childProcess_process"
         },
         "logonId": {
@@ -593,7 +593,7 @@
           "object": "childProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "childProcess_parent_process"
         },
         "pid": [
@@ -842,7 +842,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "engineProcess_process"
         },
         "logonId": {
@@ -854,7 +854,7 @@
           "object": "engineProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "engineProcess_parent_process"
         },
         "pid": [
@@ -1612,7 +1612,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "serviceProcess_process"
         },
         "logonId": {
@@ -1624,7 +1624,7 @@
           "object": "serviceProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "serviceProcess_parent_process"
         },
         "pid": [
@@ -1800,7 +1800,7 @@
           "object": "asset"
         },
         "id": {
-          "key": "process.extensions.x-process-ext.process_uid",
+          "key": "process.x_unique_id",
           "object": "targetProcess_process"
         },
         "logonId": {
@@ -1812,7 +1812,7 @@
           "object": "targetProcess_process"
         },
         "parentId": {
-          "key": "process.extensions.x-process-ext.parent_process_uid",
+          "key": "process.x_unique_id",
           "object": "targetProcess_parent_process"
         },
         "pid": [

--- a/stix_shifter_modules/reaqta/test/stix_translation/test_reaqta_json_to_stix.py
+++ b/stix_shifter_modules/reaqta/test/stix_translation/test_reaqta_json_to_stix.py
@@ -60,27 +60,27 @@ DATA_RELEVANCE = find('payload.data.relevance', DATA)
 DATA_VERSION = find('payload.data.version', DATA)
 
 STIX_2_1_OBJECT_REFS = [
-    "directory--9d6f3ae4-4fb1-5eaf-a295-7ae1189befeb",
-    "file--697ce471-a30e-5867-83ab-69d38fc4c07c",
-    "user-account--80bb9f7c-1010-5f6f-bc9c-d862451be62c",
-    "file--6463fa96-e6e4-50d6-b636-792bc7fe096e",
-    "network-traffic--1447b4e4-99c4-552d-b140-07fa908504af",
-    "directory--c616d2f7-3b0a-5ccb-843c-e4592f5d5c50",
-    "user-account--a50c0708-1b89-55c6-92e9-6d93a80d2708",
-    "url--91ba42cf-130a-58f8-8a18-7613abffd412",
-    "user-account--c0152e8f-c3db-55c6-8881-7e8d8373e8a0",
-    "file--0af4f45b-8970-5c87-819f-814b93e472ca",
-    "user-account--4fe2a8d1-b519-5701-b521-1145606b1903",
-    "directory--5c0ad0f9-38c5-56c0-a059-85994be2032a",
-    "file--ffc24f98-eb84-500d-a5d5-52376ce5ffa9",
-    "user-account--da9a51b3-80fa-5e94-adb9-a78bf00d9a56",
-    "directory--0c5773ea-0ddb-5b4d-bef7-2c29818f0170",
-    "file--ce0f32cf-1b48-59f9-8139-11e01d198bfc",
-    "directory--2f2498e1-8be8-53fa-93cd-6e54220b452a",
-    "file--1b887397-3edf-5eba-961c-83f62a816661",
-    "file--19a3ab44-7c99-570a-918a-61d3bb96ecad",
-    "ipv4-addr--a47ff5c6-efeb-5caa-b606-62198d19839d",
-    "ipv4-addr--adac2d17-0bea-5ec1-8d7a-653cba4476e4"
+    "directory--13adb857-abec-5c8f-847b-bb6899c74d12",
+    "file--e947ec3d-a3a8-50e9-a408-020d4b7108ec",
+    "user-account--b421bf67-9785-501a-9321-8dc35ed7a1c5",
+    "file--92de3247-223e-5d02-b662-10053cd87404",
+    "network-traffic--3805077a-e9e7-5689-b863-85be32f5c67e",
+    "directory--0a58d0c1-59e6-5afd-8252-dcd3f13e5622",
+    "user-account--8fefa3ad-08f5-5438-846a-82e6009baab7",
+    "url--ce0d2357-0220-5e47-896b-b49b1389c813",
+    "user-account--dda9b638-8cb1-5435-9bb0-d542baf6b67c",
+    "file--86e2f685-4636-530c-923b-adaa9db11df9",
+    "user-account--38a33c9a-4221-5a52-8da7-b3f6e51d4351",
+    "directory--bf80427d-5920-5f36-aee1-c10ea3d9bccb",
+    "file--0055834d-3772-5e4d-b39e-552c3e23b6ec",
+    "user-account--7341e6ed-3ed7-5d12-a4dc-570afeb994e5",
+    "directory--e56dc833-b047-51fe-b68d-c628598415c9",
+    "file--aadaf87b-d5cb-5ff5-8115-9dcefdd26ad9",
+    "directory--c17e5aa6-ccaf-533c-a119-3244ee7651d3",
+    "file--1a114064-93a9-5b53-82fb-e9a399ce7485",
+    "file--4d2b6011-b251-5e8b-a235-bad44f6161a0",
+    "ipv4-addr--806f9213-8e92-5de7-ae9b-8e5697498d78",
+    "ipv4-addr--efabfd00-4168-536e-8995-e3837bd7111f"
 ]
 
 DATA_SOURCE = {

--- a/stix_shifter_modules/reaqta/test/stix_translation/test_reaqta_json_to_stix.py
+++ b/stix_shifter_modules/reaqta/test/stix_translation/test_reaqta_json_to_stix.py
@@ -148,7 +148,7 @@ class TestReaqtaResultsToStix(unittest.TestCase):
         proc_obj = TestReaqtaResultsToStix.get_first_of_type(objects.values(), 'process')
         
         assert(proc_obj is not None), 'process object type not found'
-        assert(proc_obj.keys() == {'type', 'extensions', 'binary_ref', 'creator_user_ref', 'pid', 'created', 'parent_ref', 'command_line'})
+        assert(proc_obj.keys() == {'type', 'x_unique_id', 'extensions', 'binary_ref', 'creator_user_ref', 'pid', 'created', 'parent_ref', 'command_line'})
         
         user_ref = proc_obj['creator_user_ref']
         assert(user_ref in objects), f"creator_user_ref with key {proc_obj['creator_user_ref']} not found"
@@ -178,11 +178,6 @@ class TestReaqtaResultsToStix(unittest.TestCase):
         assert(extensions is not None), "file extensions not found"
         assert(extensions.keys() == {'owner_sid'})
         assert(extensions['owner_sid'] == DATA_PROCESS_USER_SID)
-
-        extensions = find('extensions.x-process-ext', proc_obj)
-        assert(extensions is not None), "process extensions not found"
-        assert(extensions.keys() == {'process_uid'})
-        assert(extensions['process_uid'] == DATA_PROCESS_GUID)
 
     def test_cybox_observables_file(self):
         objects = TestReaqtaResultsToStix.get_observed_data_objects()
@@ -274,7 +269,7 @@ class TestReaqtaResultsToStix(unittest.TestCase):
         process_ref = event['process_ref']
         assert(process_ref in objects), f"process_ref with key {event['process_ref']} not found"
         process_obj = objects[process_ref]
-        assert(process_obj.keys() == {'type', 'extensions', 'binary_ref', 'creator_user_ref', 'pid', 'created', 'parent_ref', 'command_line'})
+        assert(process_obj.keys() == {'type', 'x_unique_id', 'binary_ref', 'creator_user_ref', 'pid', 'created', 'parent_ref', 'extensions', 'command_line'})
         assert(process_obj['type'] == 'process')
         assert(process_obj['command_line'] == DATA_PROCESS_COMMAND_LINE)
         binary_obj = objects[process_obj['binary_ref']]
@@ -290,7 +285,7 @@ class TestReaqtaResultsToStix(unittest.TestCase):
         parent_process_ref = event['parent_process_ref']
         assert(parent_process_ref in objects), f"parent_process_ref with key {event['parent_process_ref']} not found"
         parent_process_obj = objects[parent_process_ref]
-        assert(parent_process_obj.keys() == {'type', 'pid','extensions'})
+        assert(parent_process_obj.keys() == {'type', 'pid','x_unique_id'})
         assert(parent_process_obj['type'] == 'process')
         assert(parent_process_obj['pid'] == DATA_PROCESS_PPID)
 
@@ -437,7 +432,7 @@ class TestReaqtaResultsToStix(unittest.TestCase):
 
         proc_obj = TestReaqtaResultsToStix.get_first_cybox_of_type_stix_2_1(result_bundle_objects, 'process')
         assert(proc_obj is not None), 'process object type not found'
-        assert(proc_obj.keys() == {'type', 'extensions', 'id', 'spec_version', 'binary_ref', 'creator_user_ref', 'pid', 'created', 'parent_ref', 'command_line'})
+        assert(proc_obj.keys() == {'type', 'extensions', 'id', 'spec_version', 'binary_ref', 'creator_user_ref', 'pid', 'created', 'parent_ref', 'command_line', 'x_unique_id'})
         
         user_ref = proc_obj['creator_user_ref']
         assert(user_ref.object_id in observed_data['object_refs']), f"creator_user_ref with key {proc_obj['creator_user_ref']} not found"
@@ -462,11 +457,6 @@ class TestReaqtaResultsToStix(unittest.TestCase):
         assert(extensions.keys() == {'owner_sid'})
         assert(extensions['owner_sid'] == DATA_PROCESS_USER_SID)
 
-        extensions = find('extensions.x-process-ext', proc_obj)
-        assert(extensions is not None), "process extensions not found"
-        assert(extensions.keys() == {'process_uid'})
-        assert(extensions['process_uid'] == DATA_PROCESS_GUID)
-    
     def test_cybox_observables_network_traffic_inbound(self):
         DATA['payload']['data']['outbound'] = False
         objects = TestReaqtaResultsToStix.get_observed_data_objects()

--- a/stix_shifter_modules/sentinelone/README.md
+++ b/stix_shifter_modules/sentinelone/README.md
@@ -261,10 +261,10 @@ results
                     "type": "process",
                     "command_line": "C:\\Windows\\System32\\xx -k termsvcs",
                     "binary_ref": "6",
+                    "x_unique_id": "xx",
                     "extensions": {
                         "x-sentinelone-process": {
                             "integrity_level": "SYSTEM",
-                            "process_unique_id": "xx",
                             "publisher": "MICROSOFT WINDOWS PUBLISHER",
                             "signed_status": "signed",
                             "story_line_id": "xx",
@@ -534,10 +534,10 @@ results
                     "type": "process",
                     "command_line": "C:\\Windows\\System32\\xx -k termsvcs",
                     "binary_ref": "6",
+                    "x_unique_id": "xx",
                     "extensions": {
                         "x-sentinelone-process": {
                             "integrity_level": "SYSTEM",
-                            "process_unique_id": "xx",
                             "publisher": "MICROSOFT WINDOWS PUBLISHER",
                             "signed_status": "signed",
                             "story_line_id": "xx",
@@ -634,10 +634,10 @@ sentinelone
                     "type": "process",
                     "command_line": "C:\\Program Files (x86)\\Google\\Temp\\GUM10C0.tmp\\xx /update /sessionid {A621AB5C-61F8-473C-91D7-6C91A9F50036}",
                     "binary_ref": "5",
+                    "x_unique_id": "xx",
                     "extensions": {
                         "x-sentinelone-process": {
                             "integrity_level": "SYSTEM",
-                            "process_unique_id": "xx",
                             "publisher": "GOOGLE LLC",
                             "signed_status": "signed",
                             "story_line_id": "xx",

--- a/stix_shifter_modules/sentinelone/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/sentinelone/stix_translation/json/from_stix_map.json
@@ -101,7 +101,7 @@
         "srcProcStorylineId",
         "tgtProcStorylineId"
       ],
-      "extensions.'x-sentinelone-process'.process_unique_id": [
+      "x_unique_id": [
         "srcProcUid",
         "tgtProcUid",
         "srcProcParentUid"

--- a/stix_shifter_modules/sentinelone/stix_translation/json/stix_2_1/from_stix_map.json
+++ b/stix_shifter_modules/sentinelone/stix_translation/json/stix_2_1/from_stix_map.json
@@ -101,7 +101,7 @@
         "srcProcStorylineId",
         "tgtProcStorylineId"
       ],
-      "extensions.'x-sentinelone-process'.process_unique_id": [
+      "x_unique_id": [
         "srcProcUid",
         "tgtProcUid",
         "srcProcParentUid"

--- a/stix_shifter_modules/sentinelone/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/sentinelone/stix_translation/json/stix_2_1/to_stix_map.json
@@ -100,7 +100,7 @@
       "object": "process_file"
     },
     {
-      "key": "process.binary_ref",
+      "key": "process.image_ref",
       "object": "process",
       "references": "process_file"
     }
@@ -111,7 +111,7 @@
       "object": "process_file"
     },
     {
-      "key": "process.binary_ref",
+      "key": "process.image_ref",
       "object": "process",
       "references": "process_file"
     }
@@ -130,7 +130,7 @@
       "object": "process_file"
     },
     {
-      "key": "process.binary_ref",
+      "key": "process.image_ref",
       "object": "process",
       "references": "process_file"
     }
@@ -141,7 +141,7 @@
       "object": "process_file"
     },
     {
-      "key": "process.binary_ref",
+      "key": "process.image_ref",
       "object": "process",
       "references": "process_file"
     }
@@ -160,7 +160,7 @@
       "object": "process_file"
     },
     {
-      "key": "process.binary_ref",
+      "key": "process.image_ref",
       "object": "process",
       "references": "process_file"
     }
@@ -171,7 +171,7 @@
       "object": "process_file"
     },
     {
-      "key": "process.binary_ref",
+      "key": "process.image_ref",
       "object": "process",
       "references": "process_file"
     }
@@ -357,7 +357,7 @@
   },
   "srcProcStartTime": [
     {
-      "key": "process.created",
+      "key": "process.created_time",
       "object": "process"
     },
     {
@@ -367,7 +367,7 @@
   ],
   "tgtProcStartTime": [
     {
-      "key": "process.created",
+      "key": "process.created_time",
       "object": "process"
     },
     {
@@ -377,7 +377,7 @@
   ],
   "srcProcParentStartTime": [
     {
-      "key": "process.created",
+      "key": "process.created_time",
       "object": "parent_process"
     },
     {

--- a/stix_shifter_modules/sentinelone/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/sentinelone/stix_translation/json/stix_2_1/to_stix_map.json
@@ -498,15 +498,15 @@
     "object": "process"
   },
   "srcProcUid": {
-    "key": "process.extensions.x-sentinelone-process-ext.process_unique_id",
+    "key": "process.x_unique_id",
     "object": "process"
   },
   "tgtProcUid": {
-    "key": "process.extensions.x-sentinelone-process-ext.process_unique_id",
+    "key": "process.x_unique_id",
     "object": "process"
   },
   "srcProcParentUid": {
-    "key": "process.extensions.x-sentinelone-process-ext.process_unique_id",
+    "key": "process.x_unique_id",
     "object": "process"
   },
   "srcProcSignedStatus": {

--- a/stix_shifter_modules/sentinelone/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/sentinelone/stix_translation/json/to_stix_map.json
@@ -503,11 +503,11 @@
     "object": "process"
   },
   "srcProcUid": {
-    "key": "process.extensions.x-sentinelone-process.process_unique_id",
+    "key": "process.x_unique_id",
     "object": "process"
   },
   "tgtProcUid": {
-    "key": "process.extensions.x-sentinelone-process.process_unique_id",
+    "key": "process.x_unique_id",
     "object": "process"
   },
   "srcProcSignedStatus": {
@@ -599,7 +599,7 @@
     "object": "process"
   },
   "srcProcParentUid": {
-    "key": "process.extensions.x-sentinelone-process.process_unique_id",
+    "key": "process.x_unique_id",
     "object": "process"
   },
   "netEventDirection": {

--- a/stix_shifter_utils/stix_translation/src/json_to_stix/id_contributing_properties.json
+++ b/stix_shifter_utils/stix_translation/src/json_to_stix/id_contributing_properties.json
@@ -11,7 +11,7 @@
     "mac-addr": ["value"],
     "mutex": ["name"],
     "network-traffic": ["start", "src_ref", "dst_ref", "src_port", "dst_port", "protocols"],
-    "process": [],
+    "process": ["x_unique_id"],
     "software": ["name", "cpe", "vendor", "version"],
     "url": ["value"],
     "user-account": ["account_type", "user_id", "account_login"],

--- a/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix_translator.py
+++ b/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix_translator.py
@@ -352,7 +352,7 @@ class DataSourceObjToStixObj:
                     cybox_properties[contr_prop] = cybox[contr_prop] 
             
             if cybox_properties:
-                unique_id = cybox_type + "--" + str(uuid.uuid5(namespace=uuid.UUID(UUID5_NAMESPACE), name=json.dumps(cybox_properties)))
+                unique_id = cybox_type + "--" + str(uuid.uuid5(namespace=uuid.UUID(UUID5_NAMESPACE), name=json.dumps(cybox_properties, sort_keys=True, ensure_ascii=False, separators=(",", ":"))))
 
         if not unique_id: # STIX process or custom object used UUID4 for identifier
             unique_id = "{}--{}".format(cybox_type, str(uuid.uuid4()))
@@ -418,7 +418,7 @@ class DataSourceObjToStixObj:
 
                         if unique_id not in object_refs:
                             object_refs.append(unique_id)
-                            self.unique_cybox_objects[key] = value
+                            self.unique_cybox_objects[unique_id] = value
 
                 observation["object_refs"] = object_refs
                 observation["spec_version"] = "2.1"

--- a/tests/stix_translation/test_results_translation.py
+++ b/tests/stix_translation/test_results_translation.py
@@ -41,12 +41,12 @@ DATA = {
         }
 
 CYBOX_ID = {
-            "source-ipv4-addr": "ipv4-addr--0b6a89e3-e345-51b7-a8ee-aaff7ebf2df5", 
-            "dest-ipv4-addr": "ipv4-addr--cb8e152d-60f0-596a-81e4-a22cc4a7f063", 
-            "url": "url--8265905f-c609-52e3-ae52-6681bcd6086d", 
-            "network-traffic": "network-traffic--2ec70516-29b5-59f3-9743-3b93e97db6d8",
-            "file": "file--243f1b5f-0391-501c-bed0-17e9f204f1d2",
-            "directory": "directory--9ce39e76-d59e-5db2-8f0e-2001f689ea9d"
+            "source-ipv4-addr": "ipv4-addr--be9fc8ad-9c41-5787-a31a-e9cb561be1fb", 
+            "dest-ipv4-addr": "ipv4-addr--79c143c3-fffe-5e0d-a015-999c59b17a2f", 
+            "url": "url--528ccb4e-e65b-57d2-8aef-9eca4c7fb79f", 
+            "network-traffic": "network-traffic--b3c6f980-f0a9-5034-933a-8ab4d3c26be6",
+            "file": "file--d1bfc532-d321-5391-839f-72fba387e5b8",
+            "directory": "directory--ccb06289-24f5-52c1-a63b-7643ce036e9d"
         }
 
 OPTIONS = {}


### PR DESCRIPTION
Partially addresses this issue: https://github.com/opencybersecurityalliance/stix-shifter/issues/922 by adding `process.x_unique_id` to QRadar, Elastic ECS, CB Cloud, ReaQta, and Sentinel One.