### PR TITLE
add optional group to group connectors

### DIFF
--- a/stix_shifter_modules/aws_athena/configuration/config.json
+++ b/stix_shifter_modules/aws_athena/configuration/config.json
@@ -1,7 +1,8 @@
 {
     "connection": {
         "type": {
-            "displayName": "Amazon Athena"
+            "displayName": "Amazon Athena",
+            "group": "aws"
         },
         "help": {
             "type": "link",

--- a/stix_shifter_modules/aws_cloud_watch_logs/configuration/config.json
+++ b/stix_shifter_modules/aws_cloud_watch_logs/configuration/config.json
@@ -1,7 +1,8 @@
 {
     "connection": {
         "type": {
-            "displayName": "Amazon CloudWatch Logs"
+            "displayName": "Amazon CloudWatch Logs",
+            "group": "aws"
         },
         "help": {
             "type": "link",

--- a/stix_shifter_modules/msatp/configuration/config.json
+++ b/stix_shifter_modules/msatp/configuration/config.json
@@ -1,7 +1,8 @@
 {
     "connection": {
         "type": {
-            "displayName": "Microsoft Defender for Endpoint"
+            "displayName": "Microsoft Defender for Endpoint",
+            "group": "atp"
         },
         "host": {
             "type": "text",


### PR DESCRIPTION
if 'group' value and/or connector folder name match then those two connectors can be configured to talk to the same physical datasource instance. 