### PR TITLE
Rhacs and Google Chronicle group params

### DIFF
--- a/adapter-guide/develop-configuration-json.md
+++ b/adapter-guide/develop-configuration-json.md
@@ -24,7 +24,8 @@ The following example JSON contains the appropriate parameters that each module 
 {
     "connection": {
         "type": {
-            "default": "QRadar"
+            "default": "QRadar",
+            "group": "qradar"
         },
         "host": {
             "type": "text",

--- a/stix_shifter_modules/gcp_chronicle/configuration/config.json
+++ b/stix_shifter_modules/gcp_chronicle/configuration/config.json
@@ -1,7 +1,8 @@
 {
 	"connection": {
 		"type": {
-			"displayName": "Google Chronicle Security"
+			"displayName": "Google Chronicle Security",
+			"group": "chronicle"
 		},
 		"host": {
 			"type": "text",

--- a/stix_shifter_modules/rhacs/configuration/config.json
+++ b/stix_shifter_modules/rhacs/configuration/config.json
@@ -1,7 +1,8 @@
 {
     "connection": {
         "type": {
-            "displayName": "Red Hat Advanced Cluster Security for Kubernetes (StackRox)"
+            "displayName": "Red Hat Advanced Cluster Security for Kubernetes (StackRox)",
+            "group": "rhacs"
         },
         "host": {
             "type": "text",


### PR DESCRIPTION
Adds the group parameter to the configs for the Red Hat Advanced Cluster Security and Google Chronicle connectors. Also adds the group parameter to the developer docs.