### PR TITLE
Remove optional from indicies label

### DIFF
--- a/stix_shifter_modules/elastic_ecs/configuration/lang_en.json
+++ b/stix_shifter_modules/elastic_ecs/configuration/lang_en.json
@@ -14,7 +14,7 @@
             "description": "More details on the data source setting can be found in the specified link"
         },
         "indices": {
-            "label": "Indices (Optional)",
+            "label": "Indices",
             "description": "To search specific Elasticsearch indices, specify a single index or multiple indices in a comma separated list",
             "placeholder": "index1,index2"
         },


### PR DESCRIPTION
This removes the **(optional)** from the indices label for the Elastic ECS config file to keep it in line with other optional fields.