### PR TITLE
Updated to support query without milliseconds in darktrace connector

### DIFF
--- a/stix_shifter_modules/darktrace/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/darktrace/stix_translation/query_constructor.py
@@ -60,6 +60,8 @@ class QueryStringPatternTranslator:
         """
         try:
             time_pattern = '%Y-%m-%dT%H:%M:%S.%fZ'
+            if re.search(r"\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}Z", str(value)):        # without milli seconds
+                time_pattern = '%Y-%m-%dT%H:%M:%SZ'
             epoch = datetime(1970, 1, 1)
             converted_time = int(((datetime.strptime(value, time_pattern) - epoch).total_seconds()) * 1000)
             return converted_time


### PR DESCRIPTION
Updated to support query without milliseconds in darktrace connector. #1198 