### PR TITLE
splunk: use like, cidrmatch SPL functions for LIKE, ISSUBSET operators

### DIFF
--- a/stix_shifter_modules/splunk/stix_translation/encoders.py
+++ b/stix_shifter_modules/splunk/stix_translation/encoders.py
@@ -1,5 +1,3 @@
-import re
-
 def simple(value):
     if isinstance(value, str):
         return "\"{}\"".format(value)
@@ -7,9 +5,7 @@ def simple(value):
         return value
 
 def like(field, value):
-    encoded_value = re.escape(value).replace("\\%", ".*").replace("_", ".")
-
-    return "match({}, \"^{}$\")".format(field, encoded_value)
+    return "like({}, \"{}\")".format(field, value)
 
 def set(field, value):
     values = [str(simple(v)) for v in value.values]
@@ -17,6 +13,4 @@ def set(field, value):
     return "{} IN ({})".format(field, ', '.join(values))
 
 def matches(field, value):
-    encoded_value = value.replace("\\", "\\\\") # Splunk needs backslashes encoded in searches
-
-    return "match({}, \"{}\")".format(field, encoded_value)
+    return "match({}, \"{}\")".format(field, value)

--- a/stix_shifter_modules/splunk/stix_translation/encoders.py
+++ b/stix_shifter_modules/splunk/stix_translation/encoders.py
@@ -14,3 +14,6 @@ def set(field, value):
 
 def matches(field, value):
     return "match({}, \"{}\")".format(field, value)
+
+def subset(field, value):
+    return "cidrmatch(\"{}\", {})".format(value, field)

--- a/stix_shifter_modules/splunk/stix_translation/json/operators.json
+++ b/stix_shifter_modules/splunk/stix_translation/json/operators.json
@@ -10,7 +10,7 @@
     "ComparisonComparators.Matches": "encoders.matches",
     "ComparisonExpressionOperators.And": "AND",
     "ComparisonExpressionOperators.Or": "OR",
-    "ComparisonComparators.IsSubSet": "=",
+    "ComparisonComparators.IsSubSet": "encoders.subset",
     "ObservationOperators.And": "{expr1} OR {expr2}",
     "ObservationOperators.Or": "{expr1} OR {expr2}",
     "ObservationOperators.FollowedBy": "latest=[search {expr2} | append [makeresults 1 | eval _time=0] | head 1 | return $_time] | where {expr1}"

--- a/stix_shifter_modules/splunk/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/splunk/stix_translation/query_constructor.py
@@ -200,6 +200,8 @@ class _ObservationExpressionTranslator:
                 comparison = encoders.set(field_mapping, expression.value)
             elif comparator == "encoders.matches":
                 comparison = encoders.matches(field_mapping, expression.value)
+            elif comparator == "encoders.subset":
+                comparison = encoders.subset(field_mapping, expression.value)
             else:
                 comparison = "{} {} {}".format(
                     field_mapping,

--- a/stix_shifter_modules/splunk/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/splunk/stix_translation/query_constructor.py
@@ -22,6 +22,10 @@ def stix_strptime(date_string):
         return datetime.strptime(date_string, stix_date_format_secs)
 
 
+def _needs_where_command(translated_query_str):
+    return bool(re.search(r'(like|match)\(', translated_query_str))
+
+
 class SplunkSearchTranslator:
     """ The core translator class. Instances should not be re-used """
 
@@ -80,21 +84,35 @@ class SplunkSearchTranslator:
                     latest_dt = latest_obj.strftime(splunk_date_format)
 
                 # prepare splunk SPL query
-                if earliest and latest:
-                    return '{query_string} earliest="{earliest}" latest="{latest}"'.format(query_string=translated_query_str,
-                                                                                           earliest=earliest_dt,
-                                                                                           latest=latest_dt)
-                elif earliest:
-                    return '{query_string} earliest="{earliest}"'.format(query_string=translated_query_str,
-                                                                         earliest=earliest_dt)
-                elif latest:
-                    return '{query_string} latest="{latest}"'.format(query_string=translated_query_str,
-                                                                     latest=latest_dt)
+                if _needs_where_command(translated_query_str):
+                    if earliest and latest:
+                        return 'earliest="{earliest}" latest="{latest}" | where {query_string}'.format(query_string=translated_query_str,
+                                                                                                       earliest=earliest_dt,
+                                                                                                       latest=latest_dt)
+                    elif earliest:
+                        return 'earliest="{earliest}" | where {query_string}'.format(query_string=translated_query_str,
+                                                                                     earliest=earliest_dt)
+                    elif latest:
+                        return 'latest="{latest}" | where {query_string}'.format(query_string=translated_query_str,
+                                                                                 latest=latest_dt)
+                    else:
+                        raise NotImplementedError("Qualifier type not implemented")
                 else:
-                    raise NotImplementedError("Qualifier type not implemented")
+                    if earliest and latest:
+                        return '{query_string} earliest="{earliest}" latest="{latest}"'.format(query_string=translated_query_str,
+                                                                                               earliest=earliest_dt,
+                                                                                               latest=latest_dt)
+                    elif earliest:
+                        return '{query_string} earliest="{earliest}"'.format(query_string=translated_query_str,
+                                                                             earliest=earliest_dt)
+                    elif latest:
+                        return '{query_string} latest="{latest}"'.format(query_string=translated_query_str,
+                                                                         latest=latest_dt)
+                    else:
+                        raise NotImplementedError("Qualifier type not implemented")
             else:
                 # Setting time_range value if START and STOP qualifiers are absent.
-                return '{query_string}'.format(query_string=translated_query_str)
+                return translated_query_str
 
         elif isinstance(expression, CombinedObservationExpression):
             combined_expr_format_string = self.comparator_lookup[str(expression.operator)]
@@ -236,7 +254,12 @@ def translate_pattern(pattern: Pattern, data_model_mapping, search_key, options)
         translated_query = f'index={index} {translated_query}'
 
     if not has_earliest_latest:
-        translated_query += ' earliest="{earliest}" | head {result_limit}'.format(earliest=time_range, result_limit=result_limit)
+        if _needs_where_command(translated_query):
+            translated_query = 'earliest="{earliest}" | where {qry} | head {result_limit}'.format(qry=translated_query,
+                                                                                                  earliest=time_range,
+                                                                                                  result_limit=result_limit)
+        else:
+            translated_query += ' earliest="{earliest}" | head {result_limit}'.format(earliest=time_range, result_limit=result_limit)
     elif has_earliest_latest:
         translated_query += ' | head {result_limit}'.format(result_limit=result_limit)
 

--- a/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -325,6 +325,30 @@ class TestStixToSpl(unittest.TestCase, object):
         queries = f'search ((src_ip IN ("192.168.122.83", "192.168.122.84")) OR (dest_ip IN ("192.168.122.83", "192.168.122.84"))) earliest="-5minutes" | head 10000 | fields {fields}'
         _test_query_assertions(query, queries)
 
+    def test_like(self):
+        stix_pattern = "[file:name LIKE 'x_.%']"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = f'search earliest="-5minutes" | where (like(file_name, "x_.%")) | head 10000 | fields {fields}'
+        _test_query_assertions(query, queries)
+
+    def test_like_or_equal(self):
+        stix_pattern = "[file:name LIKE 'x_.%' OR file:name = 'y1.exe']"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = f'search earliest="-5minutes" | where ((file_name = "y1.exe") OR (like(file_name, "x_.%"))) | head 10000 | fields {fields}'
+        _test_query_assertions(query, queries)
+
+    def test_match(self):
+        stix_pattern = r"[file:name MATCHES '^x.\\..*$']"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = f'search earliest="-5minutes" | where (match(file_name, "^x.\\..*$")) | head 10000 | fields {fields}'
+        _test_query_assertions(query, queries)
+
+    def test_match_or_equal(self):
+        stix_pattern = r"[file:name MATCHES '^x.\\..*$' OR file:name = 'y1.exe']"
+        query = translation.translate('splunk', 'query', '{}', stix_pattern)
+        queries = f'search earliest="-5minutes" | where ((file_name = "y1.exe") OR (match(file_name, "^x.\\..*$"))) | head 10000 | fields {fields}'
+        _test_query_assertions(query, queries)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
+++ b/stix_shifter_modules/splunk/tests/stix_translation/test_splunk_stix_to_spl.py
@@ -223,7 +223,7 @@ class TestStixToSpl(unittest.TestCase, object):
     def test_issubset_operator(self):
         stix_pattern = "[ipv4-addr:value ISSUBSET '198.51.100.0/24']"
         query = translation.translate('splunk', 'query', '{}', stix_pattern)
-        queries = f'search ((src_ip = "198.51.100.0/24") OR (dest_ip = "198.51.100.0/24")) earliest="-5minutes" | head 10000 | fields {fields}'
+        queries = f'search earliest="-5minutes" | where ((cidrmatch("198.51.100.0/24", src_ip)) OR (cidrmatch("198.51.100.0/24", dest_ip))) | head 10000 | fields {fields}'
         _test_query_assertions(query, queries)
 
     def test_custom_time_limit_and_result_count(self):


### PR DESCRIPTION
Fixes #1242 
Fixes #1243 
Also fixes the MATCH operator (`match()` SPL function) which must be used with the `where` command (see https://docs.splunk.com/Documentation/Splunk/9.0.2/SearchReference/ConditionalFunctions#match.28.26lt.3Bstr.26gt.3B.2C_.26lt.3Bregex.26gt.3B.29)