### PR TITLE
change all two lettered property names

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -632,7 +632,7 @@
       "object": "event"
     },
     "id": {
-      "key": "x-oca-event.id",
+      "key": "x-oca-event.event_id",
       "object": "event"
     },
     "category": {
@@ -1064,7 +1064,7 @@
     },
     "id": [
       {
-        "key": "x-ecs-user.id",
+        "key": "x-ecs-user.user_id",
         "object": "x_user"
       },
       {
@@ -1152,7 +1152,7 @@
   },
   "container": {
     "id": {
-      "key": "x-ecs-container.id",
+      "key": "x-ecs-container.container_id",
       "object": "container"
     },
     "image": {
@@ -1353,7 +1353,7 @@
       "object": "error"
     },
     "id": {
-      "key": "x-ecs-error.id",
+      "key": "x-ecs-error.error_id",
       "object": "error"
     },
     "message": {
@@ -1526,7 +1526,7 @@
       "object": "group"
     },
     "id": {
-      "key": "x-ecs-group.id",
+      "key": "x-ecs-group.group_id",
       "object": "group"
     },
     "name": {
@@ -1555,7 +1555,7 @@
       }
     ],
     "id": {
-      "key": "x-oca-asset.id",
+      "key": "x-oca-asset.host_id",
       "object": "host"
     },
     "ip": [
@@ -1953,7 +1953,7 @@
   },
   "organization": {
     "id": {
-      "key": "x-ecs-organization.id",
+      "key": "x-ecs-organization.organization_id",
       "object": "organization"
     },
     "name": {
@@ -2046,7 +2046,7 @@
       "object": "rule"
     },
     "id": {
-      "key": "x-ecs-rule.id",
+      "key": "x-ecs-rule.rule_id",
       "object": "rule"
     },
     "license": {
@@ -2076,7 +2076,7 @@
   },
   "service": {
     "id": {
-      "key": "x-ecs-service.id",
+      "key": "x-ecs-service.service_id",
       "object": "service"
     },
     "name": {
@@ -2264,13 +2264,13 @@
   },
   "trace": {
     "id": {
-      "key": "x-ecs-trace.id",
+      "key": "x-ecs-trace.trace_id",
       "object": "trace"
     }
   },
   "transaction": {
     "id": {
-      "key": "x-ecs-transaction.id",
+      "key": "x-ecs-transaction.transaction_id",
       "object": "transaction"
     }
   },
@@ -2312,7 +2312,7 @@
       "object": "vulnerability"
     },
     "id": {
-      "key": "x-ecs-vulnerability.id",
+      "key": "x-ecs-vulnerability.vulnerability_id",
       "object": "vulnerability"
     },
     "reference": {


### PR DESCRIPTION
fixes issue #1249 - property keys with two letter names are illegal in stix and cause stix validator to fail validation