### PR TITLE
STIX Bundle connector default time range

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ pytest-cov==4.0.0
 six==1.12.0
 wrapt==1.14.1
 requests_mock==1.7.0
+freezegun==1.2.2

--- a/stix_shifter_modules/stix_bundle/stix_translation/query_translator.py
+++ b/stix_shifter_modules/stix_bundle/stix_translation/query_translator.py
@@ -1,11 +1,20 @@
 from stix_shifter_utils.modules.base.stix_translation.empty_query_translator import EmptyQueryTranslator
 import re
+from datetime import datetime, timedelta
 
-START_STOP_PATTERN = "\s?START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d+)?Z'\sSTOP\s?t'\d{4}(-\d{2}){2}T(\d{2}:){2}\d{2}.\d{1,3}Z'\s?"
+START_STOP_PATTERN = r"\s?START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d{1,3})?Z'\sSTOP\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d{1,3})?Z'\s?"
 
 
 class QueryTranslator(EmptyQueryTranslator):
 
     def transform_query(self, data):
         # Data is a STIX pattern.
+        if not re.search(START_STOP_PATTERN, data):
+            # add START STOP qualifier for last 5 minutes if none present
+            now = datetime.now()
+            five_minute_delta = timedelta(minutes=5)
+            five_minutes_ago = now - five_minute_delta
+            start_time = five_minutes_ago.strftime("START t'%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z'"
+            stop_time = now.strftime("STOP t'%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z'"
+            data = data + " " + start_time + " " + stop_time
         return {'queries': [data]}

--- a/stix_shifter_modules/stix_bundle/stix_translation/query_translator.py
+++ b/stix_shifter_modules/stix_bundle/stix_translation/query_translator.py
@@ -8,13 +8,16 @@ START_STOP_PATTERN = r"\s?START\s?t'\d{4}(-\d{2}){2}T\d{2}(:\d{2}){2}(\.\d{1,3})
 class QueryTranslator(EmptyQueryTranslator):
 
     def transform_query(self, data):
+
+        time_range = self.options['time_range'] # Passed from global config
+
         # Data is a STIX pattern.
         if not re.search(START_STOP_PATTERN, data):
-            # add START STOP qualifier for last 5 minutes if none present
+            # add START STOP qualifier for last x minutes if none present
             now = datetime.now()
-            five_minute_delta = timedelta(minutes=5)
-            five_minutes_ago = now - five_minute_delta
-            start_time = five_minutes_ago.strftime("START t'%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z'"
+            timerange_delta = timedelta(minutes=time_range)
+            some_minutes_ago = now - timerange_delta
+            start_time = some_minutes_ago.strftime("START t'%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z'"
             stop_time = now.strftime("STOP t'%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z'"
             data = data + " " + start_time + " " + stop_time
         return {'queries': [data]}

--- a/stix_shifter_modules/stix_bundle/test/test_stix_bundle_default_time.py
+++ b/stix_shifter_modules/stix_bundle/test/test_stix_bundle_default_time.py
@@ -1,0 +1,28 @@
+import unittest
+from stix_shifter.stix_translation import stix_translation
+from freezegun import freeze_time
+
+
+translation = stix_translation.StixTranslation()
+
+def _test_query_assertions(query, expected_query):
+    assert query['queries'] == [expected_query]
+
+def _translate_query(stix_pattern):
+    return translation.translate('stix_bundle', 'query', '{}', stix_pattern)
+
+class TestQueryTranslator(unittest.TestCase, object):
+
+    @freeze_time("2023-01-18 01:30:00")
+    def test_pattern_without_timestamps(self):
+        stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
+        query = _translate_query(stix_pattern)
+        expected_query = "[ipv4-addr:value = '192.168.122.83'] START t'2023-01-18T01:25:00.000Z' STOP t'2023-01-18T01:30:00.000Z'"
+        _test_query_assertions(query, expected_query)
+
+    def test_pattern_with_timestamps(self):
+        stix_pattern = "[ipv4-addr:value = '192.168.122.83'] START t'2019-03-28T12:24:01.009Z' STOP t'2019-03-28T12:54:01.009Z'"
+        query = _translate_query(stix_pattern)
+        expected_query = "[ipv4-addr:value = '192.168.122.83'] START t'2019-03-28T12:24:01.009Z' STOP t'2019-03-28T12:54:01.009Z'"
+        _test_query_assertions(query, expected_query)
+

--- a/stix_shifter_modules/stix_bundle/test/test_stix_bundle_default_time.py
+++ b/stix_shifter_modules/stix_bundle/test/test_stix_bundle_default_time.py
@@ -8,16 +8,24 @@ translation = stix_translation.StixTranslation()
 def _test_query_assertions(query, expected_query):
     assert query['queries'] == [expected_query]
 
-def _translate_query(stix_pattern):
-    return translation.translate('stix_bundle', 'query', '{}', stix_pattern)
+def _translate_query(stix_pattern, options={}):
+    return translation.translate('stix_bundle', 'query', '{}', stix_pattern, options)
 
 class TestQueryTranslator(unittest.TestCase, object):
 
     @freeze_time("2023-01-18 01:30:00")
-    def test_pattern_without_timestamps(self):
+    def test_pattern_without_timestamps_with_default_range(self):
         stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
         query = _translate_query(stix_pattern)
         expected_query = "[ipv4-addr:value = '192.168.122.83'] START t'2023-01-18T01:25:00.000Z' STOP t'2023-01-18T01:30:00.000Z'"
+        _test_query_assertions(query, expected_query)
+
+    @freeze_time("2022-02-18 02:40:50")
+    def test_pattern_without_timestamps_with_custom_range(self):
+        stix_pattern = "[ipv4-addr:value = '192.168.122.83']"
+        options = {"time_range": 15}
+        query = _translate_query(stix_pattern, options)
+        expected_query = "[ipv4-addr:value = '192.168.122.83'] START t'2022-02-18T02:25:50.000Z' STOP t'2022-02-18T02:40:50.000Z'"
         _test_query_assertions(query, expected_query)
 
     def test_pattern_with_timestamps(self):


### PR DESCRIPTION
Uses the default search time range as defined in the global config if no START STOP qualifier is passed in the pattern