### PR TITLE
elastic_ecs: remove unneeded ValueToList transformer from event.category mapping

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -637,8 +637,7 @@
     },
     "category": {
       "key": "x-oca-event.category",
-      "object": "event",
-      "transformer": "ValueToList"
+      "object": "event"
     },
     "code": {
       "key": "x-oca-event.code",


### PR DESCRIPTION
Fixes #1302 