### PR TITLE
elastic_ecs: fix STIX 2.1 results translation

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/results_translator.py
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/results_translator.py
@@ -25,16 +25,9 @@ class ResultTranslator(JSONToStix):
                 event = result['event']
                 if event.get('original'):
                     result['event']['mime_type_event'] = 'text/plain'
-        
+
         data = json.dumps(results, indent=4)
 
         results = super().translate_results(data_source, data)
-        json_data = json.loads(data)
-
-        if len(results['objects']) - 1 == len(json_data):
-            for i in range(1, len(results['objects'])):
-                results['objects'][i]['number_observed'] = 1
-        else:
-            raise RuntimeError("Incorrect number of result objects after translation. Found: {}, expected: {}.".format(len(results['objects']) - 1, len(json_data)))
 
         return results

--- a/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
+++ b/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
@@ -201,6 +201,32 @@ class TestElasticEcsTransform(unittest.TestCase, object):
         assert (observed_data['id'] is not None)
         assert (observed_data['type'] == "observed-data")
         assert (observed_data['created_by_ref'] == result_bundle_identity['id'])
+        assert (observed_data['created'] is not None)
+        assert (observed_data['modified'] is not None)
+        assert (observed_data['number_observed'] == 1)
+
+    def test_stix_2_1(self):
+        test_source = json.dumps(data_source)
+        test_data = json.dumps([data])
+        test_options = {
+            "stix_2.1": True
+        }
+
+        translation = stix_translation.StixTranslation()
+        result_bundle = translation.translate('elastic_ecs', 'results', test_source, test_data, test_options)
+        print(result_bundle)
+        result_bundle_objects = result_bundle['objects']
+        observed_data = result_bundle_objects[1]
+
+        assert (observed_data['id'] is not None)
+        assert (observed_data['type'] == "observed-data")
+        assert (observed_data['created_by_ref'] == data_source['id'])
+        assert (observed_data['created'] is not None)
+        assert (observed_data['modified'] is not None)
+        assert (observed_data['number_observed'] == 1)
+        assert('object_refs' in observed_data)
+        assert('objects' not in observed_data)
+        #TODO: check other objects
 
     def test_custom_mapping(self):
         data_source_string = json.dumps(data_source)


### PR DESCRIPTION
Remove unnecessary result processing that raised the exception for STIX 2.1.

Fixes #1304 