### PR TITLE
QRadarEpochToTimestamp for exponential notation

### DIFF
--- a/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/stix_2_1/to_stix_map.json
@@ -160,24 +160,24 @@
   "starttime": [
     {
       "key": "first_observed",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "cybox": false
     },
     {
       "key": "x-ibm-finding.start",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "object": "finding"
     }
   ],
   "endtime": [
     {
       "key": "last_observed",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "cybox": false
     },
     {
       "key": "x-ibm-finding.end",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "object": "finding"
     }
   ],

--- a/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/qradar/stix_translation/json/to_stix_map.json
@@ -160,24 +160,24 @@
   "starttime": [
     {
       "key": "first_observed",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "cybox": false
     },
     {
       "key": "x-ibm-finding.start",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "object": "finding"
     }
   ],
   "endtime": [
     {
       "key": "last_observed",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "cybox": false
     },
     {
       "key": "x-ibm-finding.end",
-      "transformer": "EpochToTimestamp",
+      "transformer": "QRadarEpochToTimestamp",
       "object": "finding"
     }
   ],

--- a/stix_shifter_modules/qradar/stix_translation/transformers.py
+++ b/stix_shifter_modules/qradar/stix_translation/transformers.py
@@ -1,5 +1,6 @@
 from stix_shifter_utils.stix_translation.src.utils.transformers import ValueTransformer
 from stix_shifter_utils.utils import logger
+from datetime import datetime, timezone
 
 LOGGER = logger.set_logger(__name__)
 
@@ -34,3 +35,13 @@ class RegValueNameToStixRegistryValues(ValueTransformer):
             return [{ 'name': value }]
         except ValueError:
             LOGGER.error("Cannot convert root key to Stix formatted windows registry key")
+
+class QRadarEpochToTimestamp(ValueTransformer):
+    """A value transformer for the 13-digit timestamps, uses float(epoch) to handle exponential notation"""
+
+    @staticmethod
+    def transform(epoch):
+        try:
+            return (datetime.fromtimestamp(float(epoch) / 1000, timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z')
+        except ValueError:
+            LOGGER.error("Cannot convert epoch value {} to timestamp".format(epoch))


### PR DESCRIPTION
When using "group by" during an AQL passthrough, it was found that Qradar can return epoch values using exponential notation (e.g 1.674125456158E12) and this would fail being transformed into a timestamp, causing the DE search to fail. 

Added a custom epoch to timestamp transformer that handles epoch values using exponential notation. 