### PR TITLE
Updated custom properties mapping in Okta with 'x_' prefix

### DIFF
--- a/adapter-guide/connectors/okta_supported_stix.md
+++ b/adapter-guide/connectors/okta_supported_stix.md
@@ -1,4 +1,4 @@
-##### Updated on 03/08/23
+##### Updated on 03/15/23
 ## Okta
 ### Supported STIX Operators
 *Comparison AND/OR operators are inside the observation while observation AND/OR operators are between observations (square brackets).*
@@ -25,20 +25,20 @@
 | **ipv4-addr**:value | request.ipChain.ip |
 | **autonomous-system**:number | securityContext.asNumber |
 | **autonomous-system**:name | securityContext.asOrg |
-| **autonomous-system**:extensions.'x-okta-autonomous-system'.isp | securityContext.isp |
-| **autonomous-system**:extensions.'x-okta-autonomous-system'.domain_ref.name | securityContext.domain |
+| **autonomous-system**:x_isp | securityContext.isp |
+| **autonomous-system**:x_domain_ref.name | securityContext.domain |
 | **domain-name**:value | securityContext.domain |
 | **user-account**:user_id | actor.id |
 | **user-account**:display_name | actor.displayName |
 | **user-account**:account_login | actor.alternateId |
-| **user-account**:extensions.'x-okta-actor'.type | actor.type |
+| **user-account**:x_actor_type | actor.type |
 | **x-okta-target**:target_id | target.id |
 | **x-okta-target**:display_name | target.displayName |
 | **x-okta-target**:alternate_id | target.alternateId |
 | **x-okta-target**:target_type | target.type |
 | **software**:name | client.userAgent.browser |
-| **software**:extensions.'x-okta-software'.raw_user_agent | client.userAgent.rawUserAgent |
-| **software**:extensions.'x-okta-software'.client_os | client.userAgent.os |
+| **software**:x_raw_user_agent | client.userAgent.rawUserAgent |
+| **software**:x_client_os | client.userAgent.os |
 | **x-okta-client**:client_id | client.id |
 | **x-okta-client**:client_ip | client.ipAddress |
 | **x-okta-client**:device | client.device |
@@ -60,21 +60,21 @@
 | **x-oca-event**:category[*] | transaction.type |
 | **x-oca-event**:outcome | outcome.result |
 | **x-oca-event**:ip_refs[*].value | request.ipChain.ip |
-| **x-oca-event**:extensions.'x-okta-event'.event_unique_id | uuid |
-| **x-oca-event**:extensions.'x-okta-event'.severity | severity |
-| **x-oca-event**:extensions.'x-okta-event'.event_description | displayMessage |
-| **x-oca-event**:extensions.'x-okta-event'.transaction_id | transaction.id |
-| **x-oca-event**:extensions.'x-okta-event'.request_api_token_id | transaction.detail.requestApiTokenId |
-| **x-oca-event**:extensions.'x-okta-event'.legacy_event_type | legacyEventType |
-| **x-oca-event**:extensions.'x-okta-event'.outcome_reason | outcome.reason |
-| **x-oca-event**:extensions.'x-okta-event'.actor_ref.account_login | actor.alternateId |
-| **x-oca-event**:extensions.'x-okta-event'.actor_ref.user_id | actor.id |
-| **x-oca-event**:extensions.'x-okta-event'.client_ref.client_ip | client.ipAddress |
-| **x-oca-event**:extensions.'x-okta-event'.authentication_context_ref.session_id | authenticationContext.externalSessionId |
-| **x-oca-event**:extensions.'x-okta-event'.target_refs[*].target_type | target.type |
-| **x-oca-event**:extensions.'x-okta-event'.target_refs[*].display_name | target.displayName |
-| **x-oca-event**:extensions.'x-okta-event'.target_refs[*].target_id | target.id |
-| **x-oca-event**:extensions.'x-okta-event'.client_ref.id | client.id |
+| **x-oca-event**:x_event_unique_id | uuid |
+| **x-oca-event**:x_severity | severity |
+| **x-oca-event**:x_event_description | displayMessage |
+| **x-oca-event**:x_transaction_id | transaction.id |
+| **x-oca-event**:x_request_api_token_id | transaction.detail.requestApiTokenId |
+| **x-oca-event**:x_legacy_event_type | legacyEventType |
+| **x-oca-event**:x_outcome_reason | outcome.reason |
+| **x-oca-event**:x_actor_ref.account_login | actor.alternateId |
+| **x-oca-event**:x_actor_ref.user_id | actor.id |
+| **x-oca-event**:x_client_ref.client_ip | client.ipAddress |
+| **x-oca-event**:x_authentication_context_ref.session_id | authenticationContext.externalSessionId |
+| **x-oca-event**:x_target_refs[*].target_type| target.type |
+| **x-oca-event**:x_target_refs[*].display_name | target.displayName |
+| **x-oca-event**:x_target_refs[*].target_id | target.id |
+| **x-oca-event**:x_client_ref.id | client.id |
 | **x-okta-debug-context**:behaviors | debugContext.debugData.behaviors |
 | **x-okta-debug-context**:request_uri | debugContext.debugData.requestUri |
 | **x-okta-debug-context**:request_id | debugContext.debugData.requestId |
@@ -91,43 +91,43 @@
 |--|--|--|
 | autonomous-system | number | asNumber |
 | autonomous-system | name | asOrg |
-| autonomous-system | extensions.x-okta-autonomous-system.isp | isp |
-| autonomous-system | extensions.x-okta-autonomous-system.domain_ref | domain |
+| autonomous-system | x_isp | isp |
+| autonomous-system | x_domain_ref | domain |
 | <br> | | |
 | domain-name | value | domain |
 | <br> | | |
 | ipv4-addr | value | ip |
 | ipv4-addr | value | ipAddress |
 | <br> | | |
-| software | extensions.x-okta-software.raw_user_agent | rawUserAgent |
-| software | extensions.x-okta-software.client_os | os |
 | software | name | browser |
+| software | x_raw_user_agent | rawUserAgent |
+| software | x_client_os | os |
 | <br> | | |
 | user-account | user_id | id |
 | user-account | display_name | displayName |
 | user-account | account_login | alternateId |
-| user-account | extensions.x-okta-actor.type | type |
-| user-account | extensions.x-okta-actor.detail_entry | detailEntry |
+| user-account | x_actor_type | type |
+| user-account | x_detail_entry | detailEntry |
 | <br> | | |
 | x-oca-event | action | eventType |
-| x-oca-event | extensions.x-okta-event.event_unique_id | uuid |
+| x-oca-event | x_event_unique_id | uuid |
 | x-oca-event | outcome | result |
-| x-oca-event | extensions.x-okta-event.outcome_reason | reason |
-| x-oca-event | extensions.x-okta-event.legacy_event_type | legacyEventType |
-| x-oca-event | extensions.x-okta-event.event_description | displayMessage |
-| x-oca-event | extensions.x-okta-event.severity | severity |
+| x-oca-event | x_outcome_reason| reason |
+| x-oca-event | x_legacy_event_type | legacyEventType |
+| x-oca-event | x_event_description | displayMessage |
+| x-oca-event | x_severity | severity |
 | x-oca-event | ip_refs | ip |
-| x-oca-event | extensions.x-okta-event.actor_ref | id |
-| x-oca-event | extensions.x-okta-event.target_refs | groupReference |
-| x-oca-event | extensions.x-okta-event.client_ref | id |
+| x-oca-event | x_actor_ref | id |
+| x-oca-event | x_target_refs | groupReference |
+| x-oca-event | x_client_ref | id |
 | x-oca-event | ip_refs | ipAddress |
-| x-oca-event | extensions.x-okta-event.client_ref | device |
-| x-oca-event | extensions.x-okta-event.client_ref | country |
-| x-oca-event | extensions.x-okta-event.transaction_id | id |
+| x-oca-event | x_client_ref | device |
+| x-oca-event | x_client_ref| country |
+| x-oca-event | x_transaction_id | id |
+| x-oca-event | x_request_api_token_id | requestApiTokenId |
 | x-oca-event | category | type |
-| x-oca-event | extensions.x-okta-event.request_api_token_id | requestApiTokenId |
-| x-oca-event | extensions.x-okta-event.debug_ref | groupReference |
-| x-oca-event | extensions.x-okta-event.authentication_context_ref | externalSessionId |
+| x-oca-event | x_authentication_context_ref | externalSessionId |
+| x-oca-event | x_debug_ref | groupReference |
 | <br> | | |
 | x-okta-authentication-context | authentication_provider | authenticationProvider |
 | x-okta-authentication-context | credential_provider | credentialProvider |

--- a/stix_shifter_modules/okta/README.md
+++ b/stix_shifter_modules/okta/README.md
@@ -183,49 +183,37 @@ results
                 "0": {
                     "type": "user-account",
                     "user_id": "00u7rkrly9sNvp7sa5d7",
-                    "extensions": {
-                        "x-okta-actor": {
-                            "type": "User"
-                        }
-                    },
+                    "x_actor_type": "User",
                     "account_login": "user@login.com",
                     "display_name": "User1"
                 },
                 "1": {
                     "type": "x-oca-event",
-                    "extensions": {
-                        "x-okta-event": {
-                            "actor_ref": "0",
-                            "client_ref": "3",
-                            "authentication_context_ref": "5",
-                            "event_description": "User report suspicious activity",
-                            "severity": "WARN",
-                            "debug_ref": "7",
-                            "legacy_event_type": "core.user.account.report_suspicious_activity_by_enduser",
-                            "transaction_id": "Y6wTfThOwKPnxngKYrJ0pgAAB3g",
-                            "event_unique_id": "4fa2f7e4-8696-11ed-8688-39c4b4d86042",
-                            "target_refs": [
-                                "8"
-                            ]
-                        }
-                    },
+                    "x_actor_ref": "0",
+                    "x_client_ref": "3",
                     "ip_refs": [
                         "4"
                     ],
+                    "x_authentication_context_ref": "5",
+                    "x_event_description": "User report suspicious activity",
                     "action": "user.account.report_suspicious_activity_by_enduser",
                     "outcome": "SUCCESS",
+                    "x_severity": "WARN",
+                    "x_debug_ref": "7",
+                    "x_legacy_event_type": "core.user.account.report_suspicious_activity_by_enduser",
                     "category": [
                         "WEB"
+                    ],
+                    "x_transaction_id": "Y6wTfThOwKPnxngKYrJ0pgAAB3g",
+                    "x_event_unique_id": "4fa2f7e4-8696-11ed-8688-39c4b4d86042",
+                    "x_target_refs": [
+                        "8"
                     ]
                 },
                 "2": {
                     "type": "software",
-                    "extensions": {
-                        "x-okta-software": {
-                            "raw_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
-                            "client_os": "Windows 10"
-                        }
-                    },
+                    "x_raw_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+                    "x_client_os": "Windows 10",
                     "name": "CHROME"
                 },
                 "3": {
@@ -256,11 +244,7 @@ results
                     "type": "autonomous-system",
                     "number": 17488,
                     "name": "hathway cable and datacom limited",
-                    "extensions": {
-                        "x-okta-autonomous-system": {
-                            "isp": "hathway ip over cable internet"
-                        }
-                    }
+                    "x_isp": "hathway ip over cable internet"
                 },
                 "7": {
                     "type": "x-okta-debug-context",
@@ -304,7 +288,7 @@ results
 #### Multiple Observation
 
 ```shell
-translate okta query '{}' "([ipv4-addr:value NOT = '5.0.1.5' AND user-account:display_name MATCHES 'abc'] AND [x-okta-authentication-context:credential_type = 'IWA'])START t'2022-12-10T16:43:26.000Z' STOP t'2023-01-15T16:43:26.003Z' OR [x-oca-event:extensions.'x-okta-event'.legacy_event_type = 'app.ldap.login.disabled_account' AND x-oca-event:outcome = 'FAILURE']START t'2023-01-01T16:43:26.000Z' STOP t'2023-02-10T16:43:26.003Z' AND [ x-oca-event:extensions.'x-okta-event'.outcome_reason = 'NETWORK_ZONE_BLACKLIST']"
+translate okta query '{}' "([ipv4-addr:value NOT = '5.0.1.5' AND user-account:display_name MATCHES 'abc'] AND [x-okta-authentication-context:credential_type = 'IWA'])START t'2022-12-10T16:43:26.000Z' STOP t'2023-01-15T16:43:26.003Z' OR [x-oca-event:x_legacy_event_type = 'app.ldap.login.disabled_account' AND x-oca-event:outcome = 'FAILURE']START t'2023-01-01T16:43:26.000Z' STOP t'2023-02-10T16:43:26.003Z' AND [ x-oca-event:x_outcome_reason = 'NETWORK_ZONE_BLACKLIST']"
 ```
 
 #### STIX Multiple observation - output
@@ -353,51 +337,39 @@ okta
                 "0": {
                     "type": "user-account",
                     "user_id": "00u7rkrly9sNvp7sa5d7",
-                    "extensions": {
-                        "x-okta-actor": {
-                            "type": "User"
-                        }
-                    },
+                    "x_actor_type": "User",
                     "account_login": "zbc@login.com",
                     "display_name": "zbc"
                 },
                 "1": {
                     "type": "x-oca-event",
-                    "extensions": {
-                        "x-okta-event": {
-                            "actor_ref": "0",
-                            "client_ref": "3",
-                            "authentication_context_ref": "5",
-                            "event_description": "Evaluation of sign-on policy",
-                            "outcome_reason": "Sign-on policy evaluation resulted in CHALLENGE",
-                            "severity": "INFO",
-                            "debug_ref": "8",
-                            "transaction_id": "Y7Jo7I8JgCIFXoYvGC9mYgAABc0",
-                            "event_unique_id": "c2f00eb4-8a5c-11ed-b791-497a3600da6e",
-                            "target_refs": [
-                                "9",
-                                "10",
-                                "11"
-                            ]
-                        }
-                    },
+                    "x_actor_ref": "0",
+                    "x_client_ref": "3",
                     "ip_refs": [
                         "4"
                     ],
+                    "x_authentication_context_ref": "5",
+                    "x_event_description": "Evaluation of sign-on policy",
                     "action": "policy.evaluate_sign_on",
                     "outcome": "CHALLENGE",
+                    "x_outcome_reason": "Sign-on policy evaluation resulted in CHALLENGE",
+                    "x_severity": "INFO",
+                    "x_debug_ref": "8",
                     "category": [
                         "WEB"
+                    ],
+                    "x_transaction_id": "Y7Jo7I8JgCIFXoYvGC9mYgAABc0",
+                    "x_event_unique_id": "c2f00eb4-8a5c-11ed-b791-497a3600da6e",
+                    "x_target_refs": [
+                        "9",
+                        "10",
+                        "11"
                     ]
                 },
                 "2": {
                     "type": "software",
-                    "extensions": {
-                        "x-okta-software": {
-                            "raw_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
-                            "client_os": "Windows 10"
-                        }
-                    },
+                    "x_raw_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+                    "x_client_os": "Windows 10",
                     "name": "CHROME"
                 },
                 "3": {
@@ -428,12 +400,8 @@ okta
                     "type": "autonomous-system",
                     "number": 14618,
                     "name": "amazon technologies inc.",
-                    "extensions": {
-                        "x-okta-autonomous-system": {
-                            "isp": "amazon.com  inc.",
-                            "domain_ref": "7"
-                        }
-                    }
+                    "x_isp": "amazon.com  inc.",
+                    "x_domain_ref": "7"
                 },
                 "7": {
                     "type": "domain-name",

--- a/stix_shifter_modules/okta/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/okta/stix_translation/json/from_stix_map.json
@@ -14,10 +14,10 @@
       "name": [
         "securityContext.asOrg"
       ],
-      "extensions.'x-okta-autonomous-system'.isp": [
+      "x_isp": [
         "securityContext.isp"
       ],
-      "extensions.'x-okta-autonomous-system'.domain_ref.name": [
+      "x_domain_ref.name": [
         "securityContext.domain"
       ]
     }
@@ -40,7 +40,7 @@
       "account_login": [
         "actor.alternateId"
       ],
-      "extensions.'x-okta-actor'.type": [
+      "x_actor_type": [
         "actor.type"
       ]
     }
@@ -66,10 +66,10 @@
       "name": [
         "client.userAgent.browser"
       ],
-      "extensions.'x-okta-software'.raw_user_agent": [
+      "x_raw_user_agent": [
         "client.userAgent.rawUserAgent"
       ],
-      "extensions.'x-okta-software'.client_os": [
+      "x_client_os": [
         "client.userAgent.os"
       ]
     }
@@ -147,49 +147,49 @@
       "ip_refs[*].value": [
         "request.ipChain.ip"
       ],
-      "extensions.'x-okta-event'.event_unique_id": [
+      "x_event_unique_id": [
         "uuid"
       ],
-      "extensions.'x-okta-event'.severity": [
+      "x_severity": [
         "severity"
       ],
-      "extensions.'x-okta-event'.event_description": [
+      "x_event_description": [
         "displayMessage"
       ],
-      "extensions.'x-okta-event'.transaction_id": [
+      "x_transaction_id": [
         "transaction.id"
       ],
-      "extensions.'x-okta-event'.request_api_token_id": [
+      "x_request_api_token_id": [
         "transaction.detail.requestApiTokenId"
       ],
-      "extensions.'x-okta-event'.legacy_event_type": [
+      "x_legacy_event_type": [
         "legacyEventType"
       ],
-      "extensions.'x-okta-event'.outcome_reason": [
+      "x_outcome_reason": [
         "outcome.reason"
       ],
-      "extensions.'x-okta-event'.actor_ref.account_login": [
+      "x_actor_ref.account_login": [
         "actor.alternateId"
       ],
-      "extensions.'x-okta-event'.actor_ref.user_id": [
+      "x_actor_ref.user_id": [
         "actor.id"
       ],
-      "extensions.'x-okta-event'.client_ref.client_ip": [
+      "x_client_ref.client_ip": [
         "client.ipAddress"
       ],
-      "extensions.'x-okta-event'.authentication_context_ref.session_id": [
+      "x_authentication_context_ref.session_id": [
         "authenticationContext.externalSessionId"
       ],
-      "extensions.'x-okta-event'.target_refs[*].target_type": [
+      "x_target_refs[*].target_type": [
         "target.type"
       ],
-      "extensions.'x-okta-event'.target_refs[*].display_name": [
+      "x_target_refs[*].display_name": [
         "target.displayName"
       ],
-      "extensions.'x-okta-event'.target_refs[*].target_id": [
+      "x_target_refs[*].target_id": [
         "target.id"
       ],
-      "extensions.'x-okta-event'.client_ref.id": [
+      "x_client_ref.id": [
         "client.id"
       ]
     }

--- a/stix_shifter_modules/okta/stix_translation/json/stix_2_1/from_stix_map.json
+++ b/stix_shifter_modules/okta/stix_translation/json/stix_2_1/from_stix_map.json
@@ -14,10 +14,10 @@
       "name": [
         "securityContext.asOrg"
       ],
-      "extensions.'x-okta-autonomous-system-ext'.isp": [
+      "x_isp": [
         "securityContext.isp"
       ],
-      "extensions.'x-okta-autonomous-system-ext'.domain_ref.name": [
+      "x_domain_ref.name": [
         "securityContext.domain"
       ]
     }
@@ -40,7 +40,7 @@
       "account_login": [
         "actor.alternateId"
       ],
-      "extensions.'x-okta-actor-ext'.type": [
+      "x_actor_type": [
         "actor.type"
       ]
     }
@@ -66,10 +66,10 @@
       "name": [
         "client.userAgent.browser"
       ],
-      "extensions.'x-okta-software-ext'.raw_user_agent": [
+      "x_raw_user_agent": [
         "client.userAgent.rawUserAgent"
       ],
-      "extensions.'x-okta-software-ext'.client_os": [
+      "x_client_os": [
         "client.userAgent.os"
       ]
     }
@@ -135,7 +135,7 @@
   },
   "x-oca-event": {
     "fields": {
-      "action": [
+      "x_action": [
         "eventType"
       ],
       "category[*]": [
@@ -147,49 +147,49 @@
       "ip_refs[*].value": [
         "request.ipChain.ip"
       ],
-      "extensions.'x-okta-event-ext'.event_unique_id": [
+      "x_event_unique_id": [
         "uuid"
       ],
-      "extensions.'x-okta-event-ext'.severity": [
+      "x_severity": [
         "severity"
       ],
-      "extensions.'x-okta-event-ext'.event_description": [
+      "x_event_description": [
         "displayMessage"
       ],
-      "extensions.'x-okta-event-ext'.transaction_id": [
+      "x_transaction_id": [
         "transaction.id"
       ],
-      "extensions.'x-okta-event-ext'.request_api_token_id": [
+      "x_request_api_token_id": [
         "transaction.detail.requestApiTokenId"
       ],
-      "extensions.'x-okta-event-ext'.legacy_event_type": [
+      "x_legacy_event_type": [
         "legacyEventType"
       ],
-      "extensions.'x-okta-event-ext'.outcome_reason": [
+      "x_outcome_reason": [
         "outcome.reason"
       ],
-      "extensions.'x-okta-event-ext'.actor_ref.account_login": [
+      "x_actor_ref.account_login": [
         "actor.alternateId"
       ],
-      "extensions.'x-okta-event-ext'.actor_ref.user_id": [
+      "x_actor_ref.user_id": [
         "actor.id"
       ],
-      "extensions.'x-okta-event-ext'.client_ref.client_ip": [
+      "x_client_ref.client_ip": [
         "client.ipAddress"
       ],
-      "extensions.'x-okta-event-ext'.authentication_context_ref.session_id": [
+      "x_authentication_context_ref.session_id": [
         "authenticationContext.externalSessionId"
       ],
-      "extensions.'x-okta-event-ext'.target_refs[*].target_type": [
+      "x_target_refs[*].target_type": [
         "target.type"
       ],
-      "extensions.'x-okta-event-ext'.target_refs[*].display_name": [
+      "x_target_refs[*].display_name": [
         "target.displayName"
       ],
-      "extensions.'x-okta-event-ext'.target_refs[*].target_id": [
+      "x_target_refs[*].target_id": [
         "target.id"
       ],
-      "extensions.'x-okta-event-ext'.client_ref.id": [
+      "x_client_ref.id": [
         "client.id"
       ]
     }

--- a/stix_shifter_modules/okta/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/okta/stix_translation/json/stix_2_1/to_stix_map.json
@@ -1,10 +1,10 @@
 {
   "eventType": {
-    "key": "x-oca-event.action",
+    "key": "x-oca-event.x_action",
     "object": "event"
   },
   "uuid": {
-    "key": "x-oca-event.extensions.x-okta-event-ext.event_unique_id",
+    "key": "x-oca-event.x_event_unique_id",
     "object": "event"
   },
   "outcome": {
@@ -13,20 +13,20 @@
       "object": "event"
     },
     "reason": {
-      "key": "x-oca-event.extensions.x-okta-event-ext.outcome_reason",
+      "key": "x-oca-event.x_outcome_reason",
       "object": "event"
     }
   },
   "legacyEventType": {
-    "key": "x-oca-event.extensions.x-okta-event-ext.legacy_event_type",
+    "key": "x-oca-event.x_legacy_event_type",
     "object": "event"
   },
   "displayMessage": {
-    "key": "x-oca-event.extensions.x-okta-event-ext.event_description",
+    "key": "x-oca-event.x_event_description",
     "object": "event"
   },
   "severity": {
-    "key": "x-oca-event.extensions.x-okta-event-ext.severity",
+    "key": "x-oca-event.x_severity",
     "object": "event"
   },
   "request": {
@@ -66,7 +66,7 @@
       "object": "as"
     },
     "isp": {
-      "key": "autonomous-system.extensions.x-okta-autonomous-system-ext.isp",
+      "key": "autonomous-system.x_isp",
       "object": "as"
     },
     "domain": [
@@ -75,7 +75,7 @@
         "object": "domain"
       },
       {
-        "key": "autonomous-system.extensions.x-okta-autonomous-system-ext.domain_ref",
+        "key": "autonomous-system.x_domain_ref",
         "object": "as",
         "references": "domain"
       }
@@ -88,7 +88,7 @@
         "object": "actor_user"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event-ext.actor_ref",
+        "key": "x-oca-event.x_actor_ref",
         "object": "event",
         "references": "actor_user"
       }
@@ -102,11 +102,11 @@
       "object": "actor_user"
     },
     "type": {
-      "key": "user-account.extensions.x-okta-actor-ext.type",
+      "key": "user-account.x_actor_type",
       "object": "actor_user"
     },
     "detailEntry": {
-      "key": "user-account.extensions.x-okta-actor-ext.detail_entry",
+      "key": "user-account.x_detail_entry",
       "object": "actor_user"
     }
   },
@@ -132,7 +132,7 @@
       "object": "target"
     },
     "groupReference": {
-      "key": "x-oca-event.extensions.x-okta-event-ext.target_refs",
+      "key": "x-oca-event.x_target_refs",
       "object": "event",
       "references": [
         "target"
@@ -147,7 +147,7 @@
         "object": "client"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event-ext.client_ref",
+        "key": "x-oca-event.x_client_ref",
         "object": "event",
         "references": "client"
       }
@@ -173,11 +173,11 @@
     ],
     "userAgent": {
       "rawUserAgent": {
-        "key": "software.extensions.x-okta-software-ext.raw_user_agent",
+        "key": "software.x_raw_user_agent",
         "object": "software"
       },
       "os": {
-        "key": "software.extensions.x-okta-software-ext.client_os",
+        "key": "software.x_client_os",
         "object": "software"
       },
       "browser": [
@@ -198,7 +198,7 @@
         "object": "client"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event-ext.client_ref",
+        "key": "x-oca-event.x_client_ref",
         "object": "event",
         "references": "client"
       }
@@ -210,7 +210,7 @@
           "object": "client"
         },
         {
-          "key": "x-oca-event.extensions.x-okta-event-ext.client_ref",
+          "key": "x-oca-event.x_client_ref",
           "object": "event",
           "references": "client"
         }
@@ -239,7 +239,7 @@
   },
   "transaction": {
     "id": {
-      "key": "x-oca-event.extensions.x-okta-event-ext.transaction_id",
+      "key": "x-oca-event.x_transaction_id",
       "object": "event"
     },
     "type": {
@@ -249,7 +249,7 @@
     },
     "detail": {
       "requestApiTokenId": {
-        "key": "x-oca-event.extensions.x-okta-event-ext.request_api_token_id",
+        "key": "x-oca-event.x_request_api_token_id",
         "object": "event"
       }
     }
@@ -260,7 +260,7 @@
       "object": "debug"
     },
     "groupReference": {
-      "key": "x-oca-event.extensions.x-okta-event-ext.debug_ref",
+      "key": "x-oca-event.x_debug_ref",
       "object": "event",
       "references": "debug",
       "group_ref": true
@@ -285,7 +285,7 @@
         "object": "auth"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event-ext.authentication_context_ref",
+        "key": "x-oca-event.x_authentication_context_ref",
         "object": "event",
         "references": "auth"
       }

--- a/stix_shifter_modules/okta/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/okta/stix_translation/json/to_stix_map.json
@@ -4,7 +4,7 @@
     "object": "event"
   },
   "uuid": {
-    "key": "x-oca-event.extensions.x-okta-event.event_unique_id",
+    "key": "x-oca-event.x_event_unique_id",
     "object": "event"
   },
   "outcome": {
@@ -13,20 +13,20 @@
       "object": "event"
     },
     "reason": {
-      "key": "x-oca-event.extensions.x-okta-event.outcome_reason",
+      "key": "x-oca-event.x_outcome_reason",
       "object": "event"
     }
   },
   "legacyEventType": {
-    "key": "x-oca-event.extensions.x-okta-event.legacy_event_type",
+    "key": "x-oca-event.x_legacy_event_type",
     "object": "event"
   },
   "displayMessage": {
-    "key": "x-oca-event.extensions.x-okta-event.event_description",
+    "key": "x-oca-event.x_event_description",
     "object": "event"
   },
   "severity": {
-    "key": "x-oca-event.extensions.x-okta-event.severity",
+    "key": "x-oca-event.x_severity",
     "object": "event"
   },
   "request": {
@@ -66,7 +66,7 @@
       "object": "as"
     },
     "isp": {
-      "key": "autonomous-system.extensions.x-okta-autonomous-system.isp",
+      "key": "autonomous-system.x_isp",
       "object": "as"
     },
     "domain": [
@@ -75,7 +75,7 @@
         "object": "domain"
       },
       {
-        "key": "autonomous-system.extensions.x-okta-autonomous-system.domain_ref",
+        "key": "autonomous-system.x_domain_ref",
         "object": "as",
         "references": "domain"
       }
@@ -88,7 +88,7 @@
         "object": "actor_user"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event.actor_ref",
+        "key": "x-oca-event.x_actor_ref",
         "object": "event",
         "references": "actor_user"
       }
@@ -102,11 +102,11 @@
       "object": "actor_user"
     },
     "type": {
-      "key": "user-account.extensions.x-okta-actor.type",
+      "key": "user-account.x_actor_type",
       "object": "actor_user"
     },
     "detailEntry": {
-      "key": "user-account.extensions.x-okta-actor.detail_entry",
+      "key": "user-account.x_detail_entry",
       "object": "actor_user"
     }
   },
@@ -132,7 +132,7 @@
       "object": "target"
     },
     "groupReference": {
-      "key": "x-oca-event.extensions.x-okta-event.target_refs",
+      "key": "x-oca-event.x_target_refs",
       "object": "event",
       "references": [
         "target"
@@ -147,7 +147,7 @@
         "object": "client"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event.client_ref",
+        "key": "x-oca-event.x_client_ref",
         "object": "event",
         "references": "client"
       }
@@ -173,11 +173,11 @@
     ],
     "userAgent": {
       "rawUserAgent": {
-        "key": "software.extensions.x-okta-software.raw_user_agent",
+        "key": "software.x_raw_user_agent",
         "object": "software"
       },
       "os": {
-        "key": "software.extensions.x-okta-software.client_os",
+        "key": "software.x_client_os",
         "object": "software"
       },
       "browser": [
@@ -198,7 +198,7 @@
         "object": "client"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event.client_ref",
+        "key": "x-oca-event.x_client_ref",
         "object": "event",
         "references": "client"
       }
@@ -210,7 +210,7 @@
           "object": "client"
         },
         {
-          "key": "x-oca-event.extensions.x-okta-event.client_ref",
+          "key": "x-oca-event.x_client_ref",
           "object": "event",
           "references": "client"
         }
@@ -239,7 +239,7 @@
   },
   "transaction": {
     "id": {
-      "key": "x-oca-event.extensions.x-okta-event.transaction_id",
+      "key": "x-oca-event.x_transaction_id",
       "object": "event"
     },
     "type": {
@@ -249,7 +249,7 @@
     },
     "detail": {
       "requestApiTokenId": {
-        "key": "x-oca-event.extensions.x-okta-event.request_api_token_id",
+        "key": "x-oca-event.x_request_api_token_id",
         "object": "event"
       }
     }
@@ -260,7 +260,7 @@
       "object": "debug"
     },
     "groupReference": {
-      "key": "x-oca-event.extensions.x-okta-event.debug_ref",
+      "key": "x-oca-event.x_debug_ref",
       "object": "event",
       "references": "debug",
       "group_ref": true
@@ -285,7 +285,7 @@
         "object": "auth"
       },
       {
-        "key": "x-oca-event.extensions.x-okta-event.authentication_context_ref",
+        "key": "x-oca-event.x_authentication_context_ref",
         "object": "event",
         "references": "auth"
       }

--- a/stix_shifter_modules/okta/test/stix_translation/test_okta_stix_to_query.py
+++ b/stix_shifter_modules/okta/test/stix_translation/test_okta_stix_to_query.py
@@ -113,7 +113,7 @@ class TestQueryTranslator(unittest.TestCase):
         self._test_query_assertions(query, queries)
 
     def test_software_MATCHES_operator(self):
-        stix_pattern = "[software:extensions.'x-okta-software'.raw_user_agent MATCHES 'Mozilla/5.0 (Windows NT 10.0; " \
+        stix_pattern = "[software:x_raw_user_agent MATCHES 'Mozilla/5.0 (Windows NT 10.0; " \
                        "Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " \
                        "Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70']"
         query = translation.translate('okta', 'query', '{}', stix_pattern)
@@ -152,7 +152,7 @@ class TestQueryTranslator(unittest.TestCase):
         self._test_query_assertions(query, queries)
 
     def test_autonomous_system_string_value_le_operator(self):
-        stix_pattern = "[autonomous-system:extensions.'x-okta-autonomous-system'.isp <= 'google']"
+        stix_pattern = "[autonomous-system:x_isp <= 'google']"
         query = translation.translate('okta', 'query', '{}', stix_pattern)
         query['queries'] = _remove_timestamp_from_query(query['queries'])
         queries = ["filter=securityContext.isp le \"google\" &since=2023-02-13T12:17:01.526Z"
@@ -170,7 +170,7 @@ class TestQueryTranslator(unittest.TestCase):
         self._test_query_assertions(query, queries)
 
     def test_x_oca_event_string_value_with_ge_operator(self):
-        stix_pattern = "[x-oca-event:extensions.'x-okta-event'.legacy_event_type >= 'app.oauth2.authorize.code']"
+        stix_pattern = "[x-oca-event:x_legacy_event_type >= 'app.oauth2.authorize.code']"
         query = translation.translate('okta', 'query', '{}', stix_pattern)
         query['queries'] = _remove_timestamp_from_query(query['queries'])
         queries = ["filter=legacyEventType ge \"app.oauth2.authorize.code\" &since=2023-02-07T05:01:26.225Z"
@@ -223,7 +223,7 @@ class TestQueryTranslator(unittest.TestCase):
 
     def test_multiple_observation_with_and_without_qualifier_query(self):
         stix_pattern = "[x-okta-target:target_id MATCHES '0oa4oexp00i4BMrzJ5d7'] START t'2022-12-19T11:00:00.000Z' " \
-                       "STOP t'2023-01-31T11:00:00.003Z' AND [software:extensions.'x-okta-software'.raw_user_agent " \
+                       "STOP t'2023-01-31T11:00:00.003Z' AND [software:x_raw_user_agent " \
                        "LIKE 'Mozilla/5.0' OR x-okta-client:device != 'Computer']"
         query = translation.translate('okta', 'query', '{}', stix_pattern)
         query['queries'] = _remove_timestamp_from_query(query['queries'])
@@ -251,7 +251,7 @@ class TestQueryTranslator(unittest.TestCase):
     def test_query_for_multiple_observation(self):
         stix_pattern = "[x-okta-target:target_id MATCHES '0oa4oexp00i4BMrzJ5d7' OR " \
                        "x-okta-client:device != 'Computer']AND[x-oca-event:outcome NOT IN ('SUCCESS','FAILURE') " \
-                       "AND x-oca-event:extensions.'x-okta-event'.legacy_event_type >= 'app.oauth2.authorize.code'] " \
+                       "AND x-oca-event:x_legacy_event_type >= 'app.oauth2.authorize.code'] " \
                        "AND [x-oca-event:action = 'app.oauth2.authorize.code']START t'2022-12-15T11:20:35.000Z' " \
                        "STOP t'2023-01-31T11:00:00.003Z'"
         query = translation.translate('okta', 'query', '{}', stix_pattern)
@@ -267,7 +267,7 @@ class TestQueryTranslator(unittest.TestCase):
     def test_query_for_multiple_observation_with_brackets(self):
         stix_pattern = "([x-okta-target:target_id MATCHES '0oa4oexp00i4BMrzJ5d7' OR " \
                        "x-okta-client:device != 'Computer'] AND [x-oca-event:outcome NOT IN ('SUCCESS','FAILURE') " \
-                       "AND x-oca-event:extensions.'x-okta-event'.legacy_event_type >= 'app.oauth2.authorize.code']) " \
+                       "AND x-oca-event:x_legacy_event_type >= 'app.oauth2.authorize.code']) " \
                        "START t'2022-10-15T11:20:35.000Z' STOP t'2023-02-03T11:00:00.003Z'" \
                        "AND [x-oca-event:action = 'app.oauth2.authorize.code']START t'2022-12-15T11:20:35.000Z' " \
                        "STOP t'2023-01-31T11:00:00.003Z'"


### PR DESCRIPTION
1. Removed extensions for custom properties and updated with 'x_' prefix.
2. Updated readme, unit test cases, okta_supported_stix.md files.