### PR TITLE
Fix for Athena error handling, error log printing in tranlsation

### DIFF
--- a/stix_shifter_modules/aws_athena/stix_transmission/query_connector.py
+++ b/stix_shifter_modules/aws_athena/stix_transmission/query_connector.py
@@ -114,7 +114,7 @@ class QueryConnector(BaseQueryConnector):
             for row in results:
                 columns.append(row['Data'][0]['VarCharValue'])
         else:
-            raise Exception("Error in getting Athena table column list")
+            raise InvalidParameterException("Error in getting Athena table column list")
         
         s3_output_bucket_with_file = s3_output_location.split('//')[1]
         s3_output_bucket = s3_output_bucket_with_file.split('/')[0]
@@ -127,6 +127,9 @@ class QueryConnector(BaseQueryConnector):
         if delete_object.get('Errors'):
             message = delete_object.get('Errors')[0].get('Message')
             raise Exception("Error in deleting s3 metadata after Athena query: " + message)
+        
+        if not columns:
+            raise InvalidParameterException('No Athena table with name ' + table)
 
         return columns
 

--- a/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix_translator.py
+++ b/stix_shifter_utils/stix_translation/src/json_to_stix/json_to_stix_translator.py
@@ -19,33 +19,41 @@ LAST_OBSERVED_KEY = 'last_observed'
 
 # convert JSON data to STIX object using map_data and transformers
 def convert_to_stix(data_source, map_data, data, transformers, options, callback=None):
+    try:
+        ds2stix = DataSourceObjToStixObj(data_source, map_data, transformers, options, callback)
 
-    ds2stix = DataSourceObjToStixObj(data_source, map_data, transformers, options, callback)
+        # map data list to list of transformed objects
+        observation = ds2stix.transform
+        results = list(map(observation, data))
 
-    # map data list to list of transformed objects
-    observation = ds2stix.transform
-    results = list(map(observation, data))
+        for stix_object in results:
+            if ds2stix.spec_version == "2.1":
+                del stix_object["objects"]
+            ds2stix.bundle["objects"].append(stix_object)
 
-    for stix_object in results:
-        if ds2stix.spec_version == "2.1":
-            del stix_object["objects"]
-        ds2stix.bundle["objects"].append(stix_object)
+        for _, value in ds2stix.unique_cybox_objects.items():
+            ds2stix.bundle["objects"].append(value)
 
-    for _, value in ds2stix.unique_cybox_objects.items():
-        ds2stix.bundle["objects"].append(value)
+        if options.get('stix_validator'):
+            if ds2stix.spec_version == "2.1":
+                # Serialize and Deserialize bundle to covert StixObjectIds to strings
+                bundle_obj = json.dumps(ds2stix.bundle, sort_keys=False)
+                bundle_obj = json.loads(bundle_obj)
+            else:
+                bundle_obj = ds2stix.bundle
+            validated_result = validate_instance(bundle_obj, ValidationOptions(version=ds2stix.spec_version))
+            print_results(validated_result)
 
-    if options.get('stix_validator'):
-        if ds2stix.spec_version == "2.1":
-            # Serialize and Deserialize bundle to covert StixObjectIds to strings
-            bundle_obj = json.dumps(ds2stix.bundle, sort_keys=False)
-            bundle_obj = json.loads(bundle_obj)
-        else:
-            bundle_obj = ds2stix.bundle
-        validated_result = validate_instance(bundle_obj, ValidationOptions(version=ds2stix.spec_version))
-        print_results(validated_result)
+        return ds2stix.bundle
 
-    return ds2stix.bundle
-
+    except Exception as e:
+        try:
+            # try to print the error line
+            logger_log = logger.set_logger(__name__)
+            logger_log.error(logger.last_tb_to_string(e))
+        except:
+            pass
+        raise e
 
 class DataSourceObjToStixObj:
     logger = logger.set_logger(__name__)

--- a/stix_shifter_utils/utils/logger.py
+++ b/stix_shifter_utils/utils/logger.py
@@ -39,3 +39,8 @@ def exception_to_string(excp):
     stack = traceback.extract_stack()[:-3] + traceback.extract_tb(excp.__traceback__)
     pretty = traceback.format_list(stack)
     return ''.join(pretty) + '\n  {} {}'.format(excp.__class__, excp)
+
+def last_tb_to_string(excp):
+    stack_summary = traceback.extract_tb(excp.__traceback__)
+    last_frame = stack_summary[-1]
+    return '{}:{} {} {}'.format(last_frame.filename, last_frame.lineno, excp.__class__, excp)


### PR DESCRIPTION
This will fix:
1. Error handling message and code when AWS Athena connection has non-existing/none-accessible DB/tables
2. Error line printing in to_stix translation that has a non descriptive error, example: "string indices must be integers"