### PR TITLE
Elastic-ecs: enable observer data in transmit

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_transmission/api_client.py
+++ b/stix_shifter_modules/elastic_ecs/stix_transmission/api_client.py
@@ -69,7 +69,7 @@ class APIClient():
 
         data = {
             "_source": {
-                "includes": ["@timestamp", "source.*", "destination.*", "event.*", "client.*", "server.*",
+                "includes": ["@timestamp", "source.*", "destination.*", "event.*", "client.*", "server.*", "observer.*",
                              "host.*", "network.*", "process.*", "user.*", "file.*", "url.*", "registry.*", "dns.*",
                              "tags"]
             },


### PR DESCRIPTION
In this PR, observer data is enabled in "transmit" to enable the mapping changes of observer data into `x-oca-asset` object to be reflected.