### PR TITLE
Elastic-ecs: Patch observer mapping to `x-oca-asset` object

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
@@ -1913,11 +1913,15 @@
     "ip": [
       {
         "key": "ipv4-addr.value",
-        "object": "observer_ip"
+        "object": "observer_ip",
+        "unwrap": true,
+        "transformer": "FilterIPv4List"
       },
       {
         "key": "ipv6-addr.value",
-        "object": "observer_ipv6"
+        "object": "observer_ipv6",
+        "unwrap": true,
+        "transformer": "FilterIPv6List"
       },
       {
         "key": "x-oca-asset.ip_refs",

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/stix_2_1/to_stix_map.json
@@ -1910,14 +1910,42 @@
         }
       }
     },
-    "ip": {
-      "key": "x-oca-asset.ip",
-      "object": "observer"
-    },
-    "mac": {
-      "key": "x-oca-asset.mac",
-      "object": "observer"
-    },
+    "ip": [
+      {
+        "key": "ipv4-addr.value",
+        "object": "observer_ip"
+      },
+      {
+        "key": "ipv6-addr.value",
+        "object": "observer_ipv6"
+      },
+      {
+        "key": "x-oca-asset.ip_refs",
+        "object": "observer",
+        "references": ["observer_ip", "observer_ipv6"]
+      }
+  ],
+    "mac": [
+      {
+        "key": "mac-addr.value",
+        "object": "observer_mac"
+      },
+      {
+        "key": "ipv4-addr.resolves_to_refs",
+        "object": "observer_ip",
+        "references": ["observer_mac"]
+      },
+      {
+        "key": "ipv6-addr.resolves_to_refs",
+        "object": "observer_ipv6",
+        "references": ["observer_mac"]
+      },
+      {
+        "key": "x-oca-asset.mac_refs",
+        "object": "observer",
+        "references": ["observer_mac"]
+      }
+  ],
     "name": {
       "key": "x-oca-asset.name",
       "object": "observer"
@@ -1928,9 +1956,9 @@
         "object": "observer_sw"
       },
       {
-        "key": "x-oca-asset.observer_software_ref",
+        "key": "x-oca-asset.os_ref",
         "object": "observer",
-        "references": "observer_sw"
+        "references": ["observer_software", "observer_sw"]
       }
     ],
     "serial_number": {
@@ -1938,13 +1966,20 @@
       "object": "observer"
     },
     "type": {
-      "key": "x-oca-asset.type",
+      "key": "x-oca-asset.host_type",
       "object": "observer"
     },
-    "vendor": {
-      "key": "software.vendor",
-      "object": "observer_sw"
-    },
+    "vendor": [
+      {
+        "key": "software.vendor",
+        "object": "observer_sw"
+      },
+      {
+        "key": "x-oca-asset.os_ref",
+        "object": "observer",
+        "references": "observer_sw"
+      }
+    ],
     "version": {
       "key": "software.version",
       "object": "observer_sw"
@@ -1956,7 +1991,7 @@
         "object": "observer_software"
         },
         {
-          "key": "x-ecs-observer.os_ref",
+          "key": "x-oca-asset.os_ref",
           "object": "observer",
           "references": "observer_software"
         }
@@ -1977,7 +2012,7 @@
           "object": "observer_geo"
         },
         {
-          "key": "x-ecs-observer.geo_ref",
+          "key": "x-oca-asset.geo_ref",
           "object": "observer",
           "references": "observer_geo"
         }

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -1991,11 +1991,15 @@
     "ip": [
       {
         "key": "ipv4-addr.value",
-        "object": "observer_ip"
+        "object": "observer_ip",
+        "unwrap": true,
+        "transformer": "FilterIPv4List"
       },
       {
         "key": "ipv6-addr.value",
-        "object": "observer_ipv6"
+        "object": "observer_ipv6",
+        "unwrap": true,
+        "transformer": "FilterIPv6List"
       },
       {
         "key": "x-oca-asset.ip_refs",

--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/to_stix_map.json
@@ -1988,14 +1988,42 @@
         }
       }
     },
-    "ip": {
-      "key": "x-oca-asset.ip",
-      "object": "observer"
-    },
-    "mac": {
-      "key": "x-oca-asset.mac",
-      "object": "observer"
-    },
+    "ip": [
+      {
+        "key": "ipv4-addr.value",
+        "object": "observer_ip"
+      },
+      {
+        "key": "ipv6-addr.value",
+        "object": "observer_ipv6"
+      },
+      {
+        "key": "x-oca-asset.ip_refs",
+        "object": "observer",
+        "references": ["observer_ip", "observer_ipv6"]
+      }
+  ],
+    "mac": [
+      {
+        "key": "mac-addr.value",
+        "object": "observer_mac"
+      },
+      {
+        "key": "ipv4-addr.resolves_to_refs",
+        "object": "observer_ip",
+        "references": ["observer_mac"]
+      },
+      {
+        "key": "ipv6-addr.resolves_to_refs",
+        "object": "observer_ipv6",
+        "references": ["observer_mac"]
+      },
+      {
+        "key": "x-oca-asset.mac_refs",
+        "object": "observer",
+        "references": ["observer_mac"]
+      }
+  ],
     "name": {
       "key": "x-oca-asset.name",
       "object": "observer"
@@ -2006,9 +2034,9 @@
         "object": "observer_sw"
       },
       {
-        "key": "x-oca-asset.observer_software_ref",
+        "key": "x-oca-asset.os_ref",
         "object": "observer",
-        "references": "observer_sw"
+        "references": ["observer_software", "observer_sw"]
       }
     ],
     "serial_number": {
@@ -2016,13 +2044,20 @@
       "object": "observer"
     },
     "type": {
-      "key": "x-oca-asset.type",
+      "key": "x-oca-asset.host_type",
       "object": "observer"
     },
-    "vendor": {
-      "key": "software.vendor",
-      "object": "observer_sw"
-    },
+    "vendor": [
+      {
+        "key": "software.vendor",
+        "object": "observer_sw"
+      },
+      {
+        "key": "x-oca-asset.os_ref",
+        "object": "observer",
+        "references": "observer_sw"
+      }
+    ],
     "version": {
       "key": "software.version",
       "object": "observer_sw"
@@ -2034,7 +2069,7 @@
         "object": "observer_software"
         },
         {
-          "key": "x-ecs-observer.os_ref",
+          "key": "x-oca-asset.os_ref",
           "object": "observer",
           "references": "observer_software"
         }
@@ -2055,7 +2090,7 @@
           "object": "observer_geo"
         },
         {
-          "key": "x-ecs-observer.geo_ref",
+          "key": "x-oca-asset.geo_ref",
           "object": "observer",
           "references": "observer_geo"
         }

--- a/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
+++ b/stix_shifter_modules/elastic_ecs/tests/stix_translation/test_elastic_ecs_json_to_stix.py
@@ -332,6 +332,54 @@ ecs_event_data = {
     }
 }
 
+observer_data = {
+    "process": {
+      "args": [
+        "C:\\Users\\Administrator\\Desktop\\abc\\abc.exe"
+      ],
+      "parent": {
+        "name": "explorer.exe",
+        "entity_id": "485466882194"
+      },
+      "start": "2023-04-01T21:21:53.540Z",
+      "pid": 9989,
+      "args_count": 1,
+      "entity_id": "485541455428",
+      "command_line": "\"C:\\Users\\Administrator\\Desktop\\abc\\abc.exe\" ",
+      "executable": "\\Device\\HarddiskVolume3\\Users\\Administrator\\Desktop\\abc\\abc.exe",
+      "hash": {
+        "sha256": "d438e472cd374d76776c2f23f654e28c6eba57081f322be7777a0d2356732fea",
+        "md5": "642e934263d1316ed0d30c7336414a89"
+      }
+    },
+    "os": {
+      "type": "windows"
+    },
+    "url": {
+      "scheme": "http"
+    },
+    "observer": {
+      "geo": {
+        "continent_name": "North America",
+        "region_iso_code": "US-TX",
+        "city_name": "Austin",
+        "country_iso_code": "US",
+        "country_name": "United States",
+        "region_name": "Texas",
+        "location": {
+          "lon": -97.7419,
+          "lat": 30.2732
+        }
+      },
+      "address": "10.0.0.101",
+      "vendor": "crowdstrike",
+      "ip": "10.0.0.101",
+      "serial_number": "6484b65c806520073f0337894bc0cd24",
+      "type": "agent",
+      "version": "1007.3.0016411.1",
+    }
+}
+
 class TestElasticEcsTransform(unittest.TestCase, object):
     @staticmethod
     def get_first(itr, constraint):
@@ -760,4 +808,44 @@ class TestElasticEcsTransform(unittest.TestCase, object):
           exec_file_software.get("version") == "10.0.17763.2145 (WinBuild.160101.0800)" and
           exec_file_software.get("x_product") == "Microsoft® Windows® Operating System" and
           exec_file_software.get("x_description") == "DSREG commandline tool" 
+        )
+
+    def test_observer(self):
+        result_bundle = run_in_thread(entry_point.translate_results, data_source, [observer_data])
+        assert (result_bundle['type'] == 'bundle')
+        translation_objects = result_bundle.get('objects')
+        assert (translation_objects and len(translation_objects) == 2)
+        observed_data = translation_objects[1]
+        stix_objects = observed_data.get("objects")
+        assert (stix_objects and (stix_objects.__class__ is dict) and (len(stix_objects) > 5))
+        observer_asset = stix_objects.get("6")
+        assert (
+            observer_asset and observer_asset.get("type") == "x-oca-asset" and
+            observer_asset.get("serial_number") == "6484b65c806520073f0337894bc0cd24" and
+            observer_asset.get("host_type") == "agent"
+        )
+        observer_geo_key = observer_asset.get("geo_ref")
+        observer_geolocation = stix_objects.get(observer_geo_key)
+        assert (
+          observer_geolocation and
+          observer_geolocation.get("type") == "x-oca-geo" and
+          observer_geolocation.get("continent_name") == "North America" and
+          observer_geolocation.get("region_iso_code") == "US-TX" and
+          observer_geolocation.get("city_name") == "Austin" and
+          observer_geolocation.get("country_iso_code") == "US" and
+          observer_geolocation.get("country_name") == "United States" and
+          observer_geolocation.get("region_name") == "Texas" 
+        )
+        observer_location = observer_geolocation.get("location")
+        assert ( 
+            observer_location and
+            observer_location.get("lon") == -97.7419 and
+            observer_location.get("lat") == 30.2732
+        )
+        observer_ip_key = observer_asset.get("ip_refs")[0]
+        observer_ip = stix_objects.get(observer_ip_key)
+        assert (
+          observer_ip and 
+          observer_ip.get("type") == "ipv4-addr" and
+          observer_ip.get("value") == "10.0.0.101" 
         )


### PR DESCRIPTION
This PR fixes the mapping of observer data to `x-oca-asset`, testing the mapping accuracy and references. 