### PR TITLE
Develop_4.x_Qradar_Filter_Zero_Values

### DIFF
--- a/stix_shifter_modules/qradar/stix_translation/results_translator.py
+++ b/stix_shifter_modules/qradar/stix_translation/results_translator.py
@@ -21,6 +21,34 @@ class ResultsTranslator(JSONToStix):
       
       if result.get('flowdestinationpayload'):
         result['mime_type_flowdestinationpayload'] = 'application/octet-stream'
+      
+      if result.get('sourceip'):
+        if result['sourceip'] == '0.0.0.0':
+          result['sourceip'] = None
+
+      if result.get('destinationip'):
+        if result['destinationip'] == '0.0.0.0':
+          result['destinationip'] = None
+
+      if result.get('sourcemac'):
+        if result['sourcemac'] == '00:00:00:00:00:00' or result['sourcemac'] == '00-00-00-00-00-00':
+          result['sourcemac'] = None
+
+      if result.get('destinationmac'):
+        if result['destinationmac'] == '00:00:00:00:00:00' or result['destinationmac'] == '00-00-00-00-00-00':
+          result['destinationmac'] = None
+
+      if result.get('identityip'):
+        if result['identityip'] == '0.0.0.0':
+          result['identityip'] = None
+
+      if result.get('sourcev6'):
+        if result['sourcev6'] == '0:0:0:0:0:0:0:0':
+          result['sourcev6'] = None
+
+      if result.get('destinationv6'):
+        if result['destinationv6'] == '0:0:0:0:0:0:0:0':
+          result['destinationv6'] = None
 
     data = json.dumps(results, indent=4)
 

--- a/stix_shifter_modules/qradar/tests/stix_translation/test_qradar_json_to_stix.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/test_qradar_json_to_stix.py
@@ -633,3 +633,34 @@ class TestTransform(object):
 
         assert(finding['start'] == START_TIMESTAMP)
         assert(finding['end'] == END_TIMESTAMP)
+
+    def test_zero_value_filtering(self):
+
+        data = [{
+            "qidname": "Information Message",
+            "sourceip": "0.0.0.0",
+            "destinationip": "0.0.0.0",
+            "sourcemac": "00-00-00-00-00-00",
+            "destinationmac": "00-00-00-00-00-00",
+            "identityip": "0.0.0.0",
+            "sourcev6": "0:0:0:0:0:0:0:0",
+            "destinationv6": "0:0:0:0:0:0:0:0",
+            "sourceport": "1234",
+            "destinationport": "1234"
+        }]
+
+        result_bundle = entry_point.translate_results(json.dumps(DATA_SOURCE), json.dumps(data))
+        observed_data = result_bundle['objects'][1]
+        objects = observed_data['objects']
+        ipv4_addr = TestTransform.get_first_of_type(objects.values(), 'ipv4-addr')
+        assert(ipv4_addr is None) 
+        ipv6_addr = TestTransform.get_first_of_type(objects.values(), 'ipv6-addr')
+        assert(ipv6_addr is None)
+        mac_addr = TestTransform.get_first_of_type(objects.values(), 'mac-addr')
+        assert(mac_addr is None)
+        x_oca_event = TestTransform.get_first_of_type(objects.values(), 'x-oca-event')
+        assert(x_oca_event['action'] == "Information Message")
+        network_traffic = TestTransform.get_first_of_type(objects.values(), 'network-traffic')
+        assert(network_traffic is not None)
+        assert('src_ref' not in network_traffic)
+        assert('dst_ref' not in network_traffic)


### PR DESCRIPTION
Addition of checks for the JSON results for zero values amongst the IP and mac addresses as this data is irrelevant it should be filtered out in order to provide more correct results in smaller size. Sets them to None.

Addition of Unit test for theses values.
