### PR TITLE
map_validator: make sure 'object' name is a str

### DIFF
--- a/map_validator/validate_mapping.py
+++ b/map_validator/validate_mapping.py
@@ -103,12 +103,17 @@ def main():
 
         # "object" is an optional name for target SCO
         obj = mapping.get('object')
+        if obj is not None:
+            if not isinstance(obj, str):
+                log_error(mapping, '"object" is not a string')
+                continue  # This is "fatal" for this mapping
 
         # Validate key
         key = mapping['key']
         if not isinstance(key, str):
             log_error(mapping, '"key" is not a string')
             continue  # This is "fatal" for this mapping
+
         otype, _, rest = key.partition('.')
         if not rest:
             # No SCO type, so it's an observed-data property


### PR DESCRIPTION
The develop version of the `aws_guardduty` to_stix maps was breaking the map validator.  Some of the "object" names in the map are lists; it's supposed to be a string.

Here's the output with this fix:
```stix_shifter_modules/aws_guardduty/stix_translation/json/to_stix_map.json:
ERROR: no "references" for ipv4-addr.x_geo_ref in mapping {'key': 'ipv4-addr.x_geo_ref', 'object': 'dst_ip'}
ERROR: no "references" for ipv4-addr.x_geo_ref in mapping {'key': 'ipv4-addr.x_geo_ref', 'object': 'dst_ip'}
ERROR: conflicting types for x-aws-kubernetes-workload kubernetes in mapping {'key': 'x-aws-kubernetes.runtime_context_ref', 'object': 'kubernetes', 'references': 'runtime'}
ERROR: "object" is not a string in mapping {'key': 'process.child_refs', 'object': ['runtime_modi_process_lineage'], 'references': 'runtime_modi_child_process_lineage'}
ERROR: conflicting types for x-aws-kubernetes-workload kubernetes in mapping {'key': 'x-aws-eks-cluster.runtime_context_ref', 'object': 'kubernetes', 'references': 'runtime'}
ERROR: "object" is not a string in mapping {'key': 'process.child_refs', 'object': ['runtime_modi_process'], 'references': 'runtime_modi_child_process'}
ERROR: conflicting types for x-aws-kubernetes-workload kubernetes in mapping {'key': 'x-aws-kubernetes.runtime_context_ref', 'object': 'kubernetes', 'references': 'runtime_file'}
ERROR: conflicting types for x-aws-kubernetes-workload kubernetes in mapping {'key': 'x-aws-kubernetes.runtime_context_ref', 'object': 'kubernetes', 'references': 'runtime'}
ERROR: "object" is not a string in mapping {'key': 'process.child_refs', 'object': ['runtime_target_lineage_process'], 'references': 'runtime_target_child_lineage_process'}
ERROR: conflicting types for x-aws-runtime-context runtime in mapping {'key': 'x-aws-runtime-details.target_process_ref', 'object': 'runtime', 'references': 'runtime_target_process'}
ERROR: conflicting types for x-aws-kubernetes-workload kubernetes in mapping {'key': 'x-aws-eks-cluster.runtime_context_ref', 'object': 'kubernetes', 'references': 'runtime'}
ERROR: "object" is not a string in mapping {'key': 'process.child_refs', 'object': ['runtime_target_process'], 'references': 'runtime_target_child_process'}
ERROR: conflicting types for user-account runtime_target_user in mapping {'key': 'process.x_unique_id', 'object': 'runtime_target_user'}
ERROR: "object" is not a string in mapping {'key': 'process.child_refs', 'object': ['runtime_obs_lineage_process'], 'references': 'runtime_obs_lineage_child_process'}
ERROR: conflicting types for x-aws-kubernetes-workload kubernetes in mapping {'key': 'x-aws-kubernetes.runtime_observed_process_ref', 'object': 'kubernetes', 'references': 'runtime_obs_process'}
ERROR: "object" is not a string in mapping {'key': 'process.child_refs', 'object': ['runtime_obs_process'], 'references': 'runtime_obs_child_process'}
ERROR: conflicting types for x-aws-kubernetes-workload kubernetes in mapping {'key': 'x-aws-kubernetes.runtime_observed_process_ref', 'object': 'kubernetes', 'references': 'runtime_obs_process'}
WARNING: nothing mapped to number_observed
```