### PR TITLE
QRADAR v4.X - Remove SNI

### DIFF
--- a/stix_shifter_modules/qradar/configuration/config.json
+++ b/stix_shifter_modules/qradar/configuration/config.json
@@ -18,10 +18,6 @@
             "default": "data-sources-qradar.html",
             "type": "link"
         },
-        "sni": {
-            "type": "text",
-            "optional": true
-        },
         "selfSignedCert": {
             "type": "password",
             "optional": true

--- a/stix_shifter_modules/qradar/configuration/lang_en.json
+++ b/stix_shifter_modules/qradar/configuration/lang_en.json
@@ -16,11 +16,6 @@
         "selfSignedCert": {
             "label": "IBM QRadar Certificate",
             "placeholder": "Paste your certificate"
-        },
-        "sni": {
-            "label": "Server name indicator",
-            "placeholder": "Add a server name indicator",
-            "description": "If your hostname or IP address does not match the common name you will need to supply a Server Name Indicator (SNI). This is used to allow a separate hostname to be provided to the TLS handshake of the resource connection."
         }
     },
     "configuration": {

--- a/stix_shifter_modules/qradar/stix_transmission/api_client.py
+++ b/stix_shifter_modules/qradar/stix_transmission/api_client.py
@@ -47,8 +47,7 @@ class APIClient():
                                     None,
                                     headers,
                                     url_modifier_function,
-                                    cert_verify=connection.get('selfSignedCert', True),
-                                    sni=connection.get('sni', None)
+                                    cert_verify=connection.get('selfSignedCert', True)
                                     )
 
     def add_endpoint_to_url_header(self, url, endpoint, headers):


### PR DESCRIPTION
Removing SNI configuration from QRadar 4.X module. Users have been pointing out that the SNI field has been removed from the QRadar assets connector configuration, and not the configuration for the connection profile for UDI. This is due to SNI only being removed in versions 5.X and not versions 4.X (What they see and use). This is causing confusion for users and bugs are being raised around this. 