### PR TITLE
Mapping Fixes for AWS GuardDuty

### DIFF
--- a/stix_shifter_modules/aws_guardduty/README.md
+++ b/stix_shifter_modules/aws_guardduty/README.md
@@ -643,7 +643,7 @@ aws_guardduty
     },
     "first_observed": "2023-06-08T08:22:10.062Z",
     "last_observed": "2023-06-08T08:22:11.192Z",
-    "number_observed": 1
+    "number_observed": 2
 }
 ```
 ### Observations

--- a/stix_shifter_modules/aws_guardduty/README.md
+++ b/stix_shifter_modules/aws_guardduty/README.md
@@ -643,7 +643,7 @@ aws_guardduty
     },
     "first_observed": "2023-06-08T08:22:10.062Z",
     "last_observed": "2023-06-08T08:22:11.192Z",
-    "number_observed": 2
+    "number_observed": 1
 }
 ```
 ### Observations

--- a/stix_shifter_modules/aws_guardduty/aws_guardduty_supported_stix.md
+++ b/stix_shifter_modules/aws_guardduty/aws_guardduty_supported_stix.md
@@ -481,12 +481,13 @@
 | x-aws-kubernetes-workload | workload_type |  Resource.KubernetesDetails.KubernetesWorkloadDetails.Type |
 | x-aws-kubernetes-workload | workload_id |  Resource.KubernetesDetails.KubernetesWorkloadDetails.Uid |
 | x-aws-kubernetes-workload | volumes |  Resource.KubernetesDetails.KubernetesWorkloadDetails.Volumes |
-| <br> | | |
-| x-aws-kubernetes | runtime_context_ref | Service.RuntimeDetails.Context.ModifiedAt |
-| x-aws-kubernetes | runtime_context_ref | Service.RuntimeDetails.Context.ModuleName |
-| x-aws-kubernetes | runtime_context_ref | Service.RuntimeDetails.Context.ScriptPath |
-| x-aws-kubernetes | runtime_observed_process_ref | Service.RuntimeDetails.Process.Name |
-| x-aws-kubernetes | runtime_observed_process_ref | Service.RuntimeDetails.Process.Pid |
+| x-aws-kubernetes-workload | runtime_context_ref | Service.RuntimeDetails.Context.ModifiedAt |
+| x-aws-kubernetes-workload | runtime_context_ref | Service.RuntimeDetails.Context.ModuleName |
+| x-aws-kubernetes-workload | runtime_context_ref | Service.RuntimeDetails.Context.ScriptPath |
+| x-aws-kubernetes-workload | runtime_context_ref | Service.RuntimeDetails.Context.ModifyingProcess.Name |
+| x-aws-kubernetes-workload | runtime_context_ref | Service.RuntimeDetails.Context.TargetProcess.Name |
+| x-aws-kubernetes-workload | runtime_observed_process_ref | Service.RuntimeDetails.Process.Name |
+| x-aws-kubernetes-workload | runtime_observed_process_ref | Service.RuntimeDetails.Process.Pid |
 | <br> | | |
 | x-aws-eks-cluster | arn | Resource.EksClusterDetails.Arn |
 | x-aws-eks-cluster | created_at | Resource.EksClusterDetails.CreatedAt |
@@ -497,8 +498,6 @@
 | x-aws-eks-cluster | kubernetes_user_ref | Resource.KubernetesDetails.KubernetesUserDetails.Uid |
 | x-aws-eks-cluster | kubernetes_user_ref | Resource.KubernetesDetails.KubernetesUserDetails.Username |
 | x-aws-eks-cluster | kubernetes_workload_ref | Resource.kubernetesDetails.kubernetesWorkloadDetails.Name |
-| x-aws-eks-cluster | runtime_context_ref | Service.RuntimeDetails.Context.ModifyingProcess.Name |
-| x-aws-eks-cluster | runtime_context_ref | Service.RuntimeDetails.Context.TargetProcess.Name |
 | <br> | | |
 | x-aws-ebs-volume-malware-scan | scan_completed_at | Service.EbsVolumeScanDetails.ScanCompletedAt |
 | x-aws-ebs-volume-malware-scan | highest_severity_threat.total_infected_files | Service.EbsVolumeScanDetails.ScanDetections.HighestSeverityThreatDetails.Count |
@@ -582,6 +581,7 @@
 | x-aws-runtime-context | script_path | Service.RuntimeDetails.Context.ScriptPath |
 | x-aws-runtime-context | shell_history_file_path | Service.RuntimeDetails.Context.ShellHistoryFilePath |
 | x-aws-runtime-context | socket_path | Service.RuntimeDetails.Context.SocketPath |
+| x-aws-runtime-context | target_process_ref | Service.RuntimeDetails.Context.TargetProcess.Name |
 | <br> | | |
 | x-aws-threat | total_files_infected | Service.EbsVolumeScanDetails.ScanDetections.ThreatDetectedByName.ThreatNames.ItemCount |
 | x-aws-threat | threat_name | Service.EbsVolumeScanDetails.ScanDetections.ThreatDetectedByName.ThreatNames.Name |

--- a/stix_shifter_modules/aws_guardduty/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/aws_guardduty/stix_translation/json/stix_2_1/to_stix_map.json
@@ -1613,10 +1613,16 @@
       "key": "x-ibm-finding.x_archived",
       "object": "finding"
     },
-    "Count": {
-      "key": "x-ibm-finding.event_count",
-      "object": "finding"
-    },
+    "Count": [
+      {
+        "key": "x-ibm-finding.event_count",
+        "object": "finding"
+      },
+      {
+         "key": "number_observed",
+         "transformer": "ToInteger"
+      }
+    ],
     "DetectorId": {
       "key": "x-ibm-finding.x_detector_id",
       "object": "finding"

--- a/stix_shifter_modules/aws_guardduty/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/aws_guardduty/stix_translation/json/stix_2_1/to_stix_map.json
@@ -1580,7 +1580,8 @@
               },
               {
                 "key": "ipv4-addr.x_geo_ref",
-                "object": "dst_ip"
+                "object": "dst_ip",
+                "references": "remote_geo"
               }
             ]
           },
@@ -1592,7 +1593,8 @@
               },
               {
                 "key": "ipv4-addr.x_geo_ref",
-                "object": "dst_ip"
+                "object": "dst_ip",
+                "references": "remote_geo"
               }
             ]
           },
@@ -1611,10 +1613,16 @@
       "key": "x-ibm-finding.x_archived",
       "object": "finding"
     },
-    "Count": {
+    "Count": [
+      {
       "key": "x-ibm-finding.event_count",
       "object": "finding"
-    },
+      },
+      {
+        "key": "number_observed",
+        "transformer": "ToInteger"
+      }
+    ],
     "DetectorId": {
       "key": "x-ibm-finding.x_detector_id",
       "object": "finding"
@@ -1844,7 +1852,7 @@
             "transformer": "FormatDateTimeObjectToTimestamp"
           },
           {
-            "key": "x-aws-kubernetes.runtime_context_ref",
+            "key": "x-aws-kubernetes-workload.runtime_context_ref",
             "object": "kubernetes",
             "references": "runtime"
           }
@@ -1899,10 +1907,8 @@
               },
               {
                 "key": "process.child_refs",
-                "object": [
-                  "runtime_modi_process_lineage"
-                ],
-                "references": "runtime_modi_child_process_lineage"
+                "object": "runtime_modi_process_lineage",
+                "references": ["runtime_modi_child_process_lineage"]
               }
             ],
             "ParentUuid": {
@@ -1950,10 +1956,8 @@
             },
             {
               "key": "process.child_refs",
-              "object": [
-                "runtime_modi_process"
-              ],
-              "references": "runtime_modi_child_process"
+              "object": "runtime_modi_process",
+              "references": ["runtime_modi_child_process"]
             }
           ],
           "ParentUuid": {
@@ -1971,7 +1975,7 @@
               "references": "runtime_modi_process"
             },
             {
-              "key": "x-aws-eks-cluster.runtime_context_ref",
+              "key": "x-aws-kubernetes-workload.runtime_context_ref",
               "object": "kubernetes",
               "references": "runtime"
             }
@@ -1987,7 +1991,7 @@
               "references": "runtime_modi_process"
             },
             {
-              "key": "x-aws-eks-cluster.runtime_context_ref",
+              "key": "x-aws-kubernetes-workload.runtime_context_ref",
               "object": "kubernetes",
               "references": "runtime"
             }
@@ -2040,7 +2044,7 @@
             "references": "runtime_file"
           },
           {
-            "key": "x-aws-kubernetes.runtime_context_ref",
+            "key": "x-aws-kubernetes-workload.runtime_context_ref",
             "object": "kubernetes",
             "references": "runtime_file"
           }
@@ -2071,7 +2075,7 @@
             "object": "runtime"
           },
           {
-            "key": "x-aws-kubernetes.runtime_context_ref",
+            "key": "x-aws-kubernetes-workload.runtime_context_ref",
             "object": "kubernetes",
             "references": "runtime"
           }
@@ -2134,10 +2138,8 @@
               },
               {
                 "key": "process.child_refs",
-                "object": [
-                  "runtime_target_lineage_process"
-                ],
-                "references": "runtime_target_child_lineage_process"
+                "object": "runtime_target_lineage_process",
+                "references": ["runtime_target_child_lineage_process"]
               }
             ],
             "ParentUuid": {
@@ -2185,10 +2187,8 @@
             },
             {
               "key": "process.child_refs",
-              "object": [
-                "runtime_target_process"
-              ],
-              "references": "runtime_target_child_process"
+              "object": "runtime_target_process",
+              "references": ["runtime_target_child_process"]
             }
           ],
           "ParentUuid": {
@@ -2201,12 +2201,12 @@
               "object": "runtime_target_process"
             },
             {
-              "key": "x-aws-runtime-details.target_process_ref",
+              "key": "x-aws-runtime-context.target_process_ref",
               "object": "runtime",
               "references": "runtime_target_process"
             },
             {
-              "key": "x-aws-eks-cluster.runtime_context_ref",
+              "key": "x-aws-kubernetes-workload.runtime_context_ref",
               "object": "kubernetes",
               "references": "runtime"
             }
@@ -2217,12 +2217,12 @@
               "object": "runtime_target_process"
             },
             {
-              "key": "x-aws-runtime-details.target_process_ref",
+              "key": "x-aws-runtime-context.target_process_ref",
               "object": "runtime",
               "references": "runtime_target_process"
             },
             {
-              "key": "x-aws-eks-cluster.runtime_context_ref",
+              "key": "x-aws-kubernetes-workload.runtime_context_ref",
               "object": "kubernetes",
               "references": "runtime"
             }
@@ -2250,7 +2250,7 @@
           ],
           "Uuid": {
             "key": "process.x_unique_id",
-            "object": "runtime_target_user"
+            "object": "runtime_target_process"
           }
         }
       },
@@ -2303,10 +2303,8 @@
             },
             {
               "key": "process.child_refs",
-              "object": [
-                "runtime_obs_lineage_process"
-              ],
-              "references": "runtime_obs_lineage_child_process"
+              "object": "runtime_obs_lineage_process",
+              "references": ["runtime_obs_lineage_child_process"]
             }
           ],
           "ParentUuid": {
@@ -2354,10 +2352,8 @@
           },
           {
             "key": "process.child_refs",
-            "object": [
-              "runtime_obs_process"
-            ],
-            "references": "runtime_obs_child_process"
+            "object": "runtime_obs_process",
+            "references": ["runtime_obs_child_process"]
           }
         ],
         "ParentUuid": {
@@ -2370,7 +2366,7 @@
             "object": "runtime_obs_process"
           },
           {
-            "key": "x-aws-kubernetes.runtime_observed_process_ref",
+            "key": "x-aws-kubernetes-workload.runtime_observed_process_ref",
             "object": "kubernetes",
             "references": "runtime_obs_process"
           }
@@ -2381,7 +2377,7 @@
             "object": "runtime_obs_process"
           },
           {
-            "key": "x-aws-kubernetes.runtime_observed_process_ref",
+            "key": "x-aws-kubernetes-workload.runtime_observed_process_ref",
             "object": "kubernetes",
             "references": "runtime_obs_process"
           }

--- a/stix_shifter_modules/aws_guardduty/stix_translation/json/stix_2_1/to_stix_map.json
+++ b/stix_shifter_modules/aws_guardduty/stix_translation/json/stix_2_1/to_stix_map.json
@@ -1613,16 +1613,10 @@
       "key": "x-ibm-finding.x_archived",
       "object": "finding"
     },
-    "Count": [
-      {
+    "Count": {
       "key": "x-ibm-finding.event_count",
       "object": "finding"
-      },
-      {
-        "key": "number_observed",
-        "transformer": "ToInteger"
-      }
-    ],
+    },
     "DetectorId": {
       "key": "x-ibm-finding.x_detector_id",
       "object": "finding"

--- a/stix_shifter_modules/aws_guardduty/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/aws_guardduty/stix_translation/json/to_stix_map.json
@@ -1613,15 +1613,10 @@
       "key": "x-ibm-finding.x_archived",
       "object": "finding"
     },
-    "Count": [
-      {
+    "Count": {
         "key": "x-ibm-finding.event_count",
         "object": "finding"
-      },
-      {
-        "key": "number_observed",
-        "transformer": "ToInteger"
-      }],
+    },
     "DetectorId": {
       "key": "x-ibm-finding.x_detector_id",
       "object": "finding"

--- a/stix_shifter_modules/aws_guardduty/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/aws_guardduty/stix_translation/json/to_stix_map.json
@@ -1580,7 +1580,8 @@
               },
               {
                 "key": "ipv4-addr.x_geo_ref",
-                "object": "dst_ip"
+                "object": "dst_ip",
+                "references": "remote_geo"
               }
             ]
           },
@@ -1592,7 +1593,8 @@
               },
               {
                 "key": "ipv4-addr.x_geo_ref",
-                "object": "dst_ip"
+                "object": "dst_ip",
+                "references": "remote_geo"
               }
             ]
           },
@@ -1611,10 +1613,15 @@
       "key": "x-ibm-finding.x_archived",
       "object": "finding"
     },
-    "Count": {
-      "key": "x-ibm-finding.event_count",
-      "object": "finding"
-    },
+    "Count": [
+      {
+        "key": "x-ibm-finding.event_count",
+        "object": "finding"
+      },
+      {
+        "key": "number_observed",
+        "transformer": "ToInteger"
+      }],
     "DetectorId": {
       "key": "x-ibm-finding.x_detector_id",
       "object": "finding"
@@ -1844,7 +1851,7 @@
             "transformer": "FormatDateTimeObjectToTimestamp"
           },
           {
-            "key": "x-aws-kubernetes.runtime_context_ref",
+            "key": "x-aws-kubernetes-workload.runtime_context_ref",
             "object": "kubernetes",
             "references": "runtime"
           }
@@ -1903,10 +1910,8 @@
               },
               {
                 "key": "process.child_refs",
-                "object": [
-                  "runtime_modi_process_lineage"
-                ],
-                "references": "runtime_modi_child_process_lineage"
+                "object": "runtime_modi_process_lineage",
+                "references": ["runtime_modi_child_process_lineage"]
               }
             ],
             "ParentUuid": {
@@ -1958,7 +1963,7 @@
               "references": "runtime_modi_process"
             },
             {
-              "key": "x-aws-eks-cluster.runtime_context_ref",
+              "key": "x-aws-kubernetes-workload.runtime_context_ref",
               "object": "kubernetes",
               "references": "runtime"
             }
@@ -1970,10 +1975,8 @@
             },
             {
               "key": "process.child_refs",
-              "object": [
-                "runtime_modi_process"
-              ],
-              "references": "runtime_modi_child_process"
+              "object": "runtime_modi_process",
+              "references": ["runtime_modi_child_process"]
             }
           ],
           "ParentUuid": {
@@ -2036,7 +2039,7 @@
             "references": "runtime_file"
           },
           {
-            "key": "x-aws-kubernetes.runtime_context_ref",
+            "key": "x-aws-kubernetes-workload.runtime_context_ref",
             "object": "kubernetes",
             "references": "runtime_file"
           }
@@ -2067,7 +2070,7 @@
             "object": "runtime"
           },
           {
-            "key": "x-aws-kubernetes.runtime_context_ref",
+            "key": "x-aws-kubernetes-workload.runtime_context_ref",
             "object": "kubernetes",
             "references": "runtime"
           }
@@ -2134,10 +2137,8 @@
               },
               {
                 "key": "process.child_refs",
-                "object": [
-                  "runtime_target_lineage_process"
-                ],
-                "references": "runtime_target_child_lineage_process"
+                "object": "runtime_target_lineage_process",
+                "references": ["runtime_target_child_lineage_process"]
               }
             ],
             "ParentUuid": {
@@ -2184,12 +2185,12 @@
               "object": "runtime_target_process"
             },
             {
-              "key": "x-aws-runtime-details.target_process_ref",
+              "key": "x-aws-runtime-context.target_process_ref",
               "object": "runtime",
               "references": "runtime_target_process"
             },
             {
-              "key": "x-aws-eks-cluster.runtime_context_ref",
+              "key": "x-aws-kubernetes-workload.runtime_context_ref",
               "object": "kubernetes",
               "references": "runtime"
             }
@@ -2201,10 +2202,8 @@
             },
             {
               "key": "process.child_refs",
-              "object": [
-                "runtime_target_process"
-              ],
-              "references": "runtime_target_child_process"
+              "object": "runtime_target_process",
+              "references": ["runtime_target_child_process"]
             }
           ],
           "ParentUuid": {
@@ -2242,7 +2241,7 @@
           ],
           "Uuid": {
             "key": "process.x_unique_id",
-            "object": "runtime_target_user"
+            "object": "runtime_target_process"
           }
         }
       },
@@ -2299,10 +2298,8 @@
             },
             {
               "key": "process.child_refs",
-              "object": [
-                "runtime_obs_lineage_process"
-              ],
-              "references": "runtime_obs_lineage_child_process"
+              "object": "runtime_obs_lineage_process",
+              "references": ["runtime_obs_lineage_child_process"]
             }
           ],
           "ParentUuid": {
@@ -2349,7 +2346,7 @@
             "object": "runtime_obs_process"
           },
           {
-            "key": "x-aws-kubernetes.runtime_observed_process_ref",
+            "key": "x-aws-kubernetes-workload.runtime_observed_process_ref",
             "object": "kubernetes",
             "references": "runtime_obs_process"
           }
@@ -2361,10 +2358,8 @@
           },
           {
             "key": "process.child_refs",
-            "object": [
-              "runtime_obs_process"
-            ],
-            "references": "runtime_obs_child_process"
+            "object": "runtime_obs_process",
+            "references": ["runtime_obs_child_process"]
           }
         ],
         "ParentUuid": {
@@ -2377,7 +2372,7 @@
             "object": "runtime_obs_process"
           },
           {
-            "key": "x-aws-kubernetes.runtime_observed_process_ref",
+            "key": "x-aws-kubernetes-workload.runtime_observed_process_ref",
             "object": "kubernetes",
             "references": "runtime_obs_process"
           }

--- a/stix_shifter_modules/aws_guardduty/stix_translation/json/to_stix_map.json
+++ b/stix_shifter_modules/aws_guardduty/stix_translation/json/to_stix_map.json
@@ -1613,10 +1613,16 @@
       "key": "x-ibm-finding.x_archived",
       "object": "finding"
     },
-    "Count": {
+    "Count": [
+      {
         "key": "x-ibm-finding.event_count",
         "object": "finding"
-    },
+      },
+      {
+         "key": "number_observed",
+         "transformer": "ToInteger"
+      }
+    ],
     "DetectorId": {
       "key": "x-ibm-finding.x_detector_id",
       "object": "finding"


### PR DESCRIPTION
Based on the PR #1540, fixed the mapping errors thrown from  map_validator in to-stix mapping file. 
