### PR TITLE
allow host address input in MS Graph configuration

### DIFF
--- a/stix_shifter_modules/azure_sentinel/configuration/config.json
+++ b/stix_shifter_modules/azure_sentinel/configuration/config.json
@@ -4,6 +4,11 @@
             "displayName": "Microsoft Graph Security",
             "group": "microsoft"
         },
+        "host": {
+            "type": "text",
+            "regex": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_:/\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9_:/\\-]*[A-Za-z0-9])$",
+            "default": "graph.microsoft.com"
+        },
         "port": {
             "type": "number",
             "default": 443,

--- a/stix_shifter_modules/azure_sentinel/stix_transmission/api_client.py
+++ b/stix_shifter_modules/azure_sentinel/stix_transmission/api_client.py
@@ -6,11 +6,11 @@ class APIClient:
     """API Client to handle all calls."""
     credential = None
     
-    def __init__(self, base_uri, connection, configuration):
+    def __init__(self, connection, configuration):
         """Initialization.
         :param connection: dict, connection dict
         :param configuration: dict,config dict"""
-        self.host = base_uri
+        self.host = connection['host']
         self.connection = connection
         self.configuration = configuration
         self.timeout = connection['options'].get('timeout')

--- a/stix_shifter_modules/azure_sentinel/stix_transmission/connector.py
+++ b/stix_shifter_modules/azure_sentinel/stix_transmission/connector.py
@@ -9,7 +9,6 @@ from stix_shifter_utils.utils import logger
 class Connector(BaseJsonSyncConnector):
     api_client = None
     max_limit = 1000
-    base_uri = 'graph.microsoft.com' # Microsoft Graph API has single endpoint
     DEFAULT_API_VERSION = 'v1.0'
     LEGACY_ALERT = 'security/alerts'
     ALERT_V2 = 'security/alerts_v2'
@@ -22,7 +21,7 @@ class Connector(BaseJsonSyncConnector):
         self.connector = __name__.split('.')[1]
         self.connection = connection
         self.configuration = configuration
-        self.api_client = APIClient(self.base_uri, self.connection, self.configuration)
+        self.api_client = APIClient(self.connection, self.configuration)
         
         self.legacy_alert = connection['options'].get('alert')
         self.alert_v2 = connection['options'].get('alertV2')


### PR DESCRIPTION
Adds custom host input support for connecting to Microsoft Graph API. This is to allow for cases where a different host address is required for US Government agencies. https://learn.microsoft.com/en-us/answers/questions/434905/microsoft-graph-api-for-azure-us-government-plan