### PR TITLE
Add query batchsize(length) in common config.json

### DIFF
--- a/stix_shifter_modules/config.json
+++ b/stix_shifter_modules/config.json
@@ -22,7 +22,8 @@
                 "min": 1,
                 "max": 10000,
                 "type": "number",
-                "optional": true
+                "optional": true,
+                "hidden": true
             },
             "time_range": {
                 "default": 5,

--- a/stix_shifter_modules/config.json
+++ b/stix_shifter_modules/config.json
@@ -17,6 +17,13 @@
                 "type": "number",
                 "previous": "connection.resultSizeLimit"
             },
+            "batchsize": {
+                "default": 2000,
+                "min": 1,
+                "max": 10000,
+                "type": "number",
+                "optional": true
+            },
             "time_range": {
                 "default": 5,
                 "min": 1,

--- a/stix_shifter_modules/config.json
+++ b/stix_shifter_modules/config.json
@@ -17,7 +17,7 @@
                 "type": "number",
                 "previous": "connection.resultSizeLimit"
             },
-            "batchsize": {
+            "batch_size": {
                 "default": 2000,
                 "min": 1,
                 "max": 10000,

--- a/stix_shifter_modules/lang_en.json
+++ b/stix_shifter_modules/lang_en.json
@@ -8,6 +8,10 @@
                 "label": "Result size limit",
                 "description": "The maximum number of entries or objects that are returned by search query.  Valid input range is {{min}} to {{max}}."
             },
+            "batch_size": {
+                "label": "Result length for datasource request",
+                "description": "The maximum results retrive in single API request to the datasource. This is not results limit. This value is mainly used for pagination."
+            },
             "time_range": {
                 "label": "Query time range",
                 "description": "Time range for the search, in minutes, represented as last x minutes.  Valid input range is {{min}} to {{max}}."


### PR DESCRIPTION
We set the default value to 2000 and make it optional. Connector may not need to use this parameter unless it is necessary to enforce a lower query length. The caller application or script can use the value to make the query when it is necessary. The max value is arbitrary and can be changed to a different value is required.