### PR TITLE
Map validator checks single quotes and extension name in key

### DIFF
--- a/map_validator/validate_mapping.py
+++ b/map_validator/validate_mapping.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import re
 
 
 # create logging formatter
@@ -113,6 +114,11 @@ def main():
         if not isinstance(key, str):
             log_error(mapping, '"key" is not a string')
             continue  # This is "fatal" for this mapping
+        if "'" in key:
+            log_error(mapping, 'single quotes are not allowed in "key"')
+        if ".extensions." in key:
+            if re.match(r"^.*\.extensions\.[a-z]*$", key):
+                log_error(mapping, 'missing extension name in "key"')
 
         otype, _, rest = key.partition('.')
         if not rest:

--- a/stix_shifter_modules/sumologic/stix_translation/json/operators.json
+++ b/stix_shifter_modules/sumologic/stix_translation/json/operators.json
@@ -2,6 +2,7 @@
     "ComparisonExpressionOperators.And": "AND",
     "ComparisonExpressionOperators.Or": "OR",
     "ComparisonComparators.Equal": "=",
+    "ComparisonComparators.NotEqual": "=",
     "ComparisonComparators.In": "OR",
     "ObservationOperators.Or": "OR",
     "ObservationOperators.And": "AND"

--- a/stix_shifter_modules/sumologic/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/sumologic/stix_translation/query_constructor.py
@@ -110,11 +110,14 @@ class QueryStringPatternTranslator:
                         continue
                     comparison_string += parsed_reference
                 else:
-                    comparison_string += "{mapped_field} {comparator} {value}".format(mapped_field=mapped_field,
-                                                                                      comparator=comparator, value=value)
+                    format_string = "{mapped_field} {comparator} {value}"
+                    if expression.comparator == ComparisonComparators.NotEqual:
+                        format_string = self._negate_comparison(format_string)
+                    comparison_string += format_string.format(mapped_field=mapped_field,
+                                                              comparator=comparator, value=value)
 
             if mapped_fields_count > 1:
-                comparison_string += " OR "
+                comparison_string += " AND " if expression.comparator == ComparisonComparators.NotEqual else " OR "
                 mapped_fields_count -= 1
 
         return comparison_string

--- a/stix_shifter_modules/sumologic/tests/stix_translation/test_sumologic_stix_to_query.py
+++ b/stix_shifter_modules/sumologic/tests/stix_translation/test_sumologic_stix_to_query.py
@@ -157,3 +157,11 @@ class TestStixToQuery(unittest.TestCase, object):
         queries = "{\"query\": \"lastLoginTimestamp = \\\"2021-10-04T13:51:09.958Z\\\"\", \"fromTime\": \"%s\", " \
                   "\"toTime\": \"%s\"}" % (from_time, to_time)
         _test_query_assertions(query, queries)
+
+    def test_negation(self):
+        stix_pattern = "[domain-name:value != 'example.com'] " \
+                       "START t'2021-09-01T00:00:00.000Z' STOP t'2021-09-26T10:16:00.000Z'"
+        query = translation.translate('sumologic', 'query', 'sumologic', stix_pattern, options={"result_limit": 100})
+        queries = "{\"query\": \"NOT (_sourcehost = \\\"example.com\\\")\", " \
+                  "\"fromTime\": \"20210901T000000\", \"toTime\": \"20210926T101600\"}"
+        _test_query_assertions(query, queries)


### PR DESCRIPTION
Example output (for reaqta mapping):
```
ERROR: single quotes are not allowed in "key" in mapping {'key': "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.tactic_name", 'object': 'x-ibm-ttp-tagging'}
ERROR: single quotes are not allowed in "key" in mapping {'key': "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.technique_name", 'object': 'x-ibm-ttp-tagging'}
ERROR: missing extension name in "key" in mapping {'key': 'x-ibm-ttp-tagging.extensions.name', 'object': 'x-ibm-ttp-tagging'}
```

If you use single quotes in a key, such as "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.tactic_name", you'll get something like this in your JSON:
```
          "type": "x-ibm-ttp-tagging",
          "extensions": {
            "'mitre-attack-ext'": {
```
Note the single quotes in `'mitre-attack-ext'` - that's not valid.  It should be "x-ibm-ttp-tagging.extensions.mitre-attack-ext.tactic_name", I believe.

A key like "x-ibm-ttp-tagging.extensions.name" is invalid because there's no extension name (there's already an entry for "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.technique_name" so I don't know what this entry is for).