### PR TITLE
map validator: additional checks for single quotes and extensions properties

### DIFF
--- a/map_validator/validate_mapping.py
+++ b/map_validator/validate_mapping.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import re
 
 
 # create logging formatter
@@ -113,6 +114,11 @@ def main():
         if not isinstance(key, str):
             log_error(mapping, '"key" is not a string')
             continue  # This is "fatal" for this mapping
+        if "'" in key:
+            log_error(mapping, 'single quotes are not allowed in "key"')
+        if ".extensions." in key:
+            if re.match(r"^.*\.extensions\.[a-z]*$", key):
+                log_error(mapping, 'missing extension name in "key"')
 
         otype, _, rest = key.partition('.')
         if not rest:


### PR DESCRIPTION
Example output (for reaqta mapping):
```
ERROR: single quotes are not allowed in "key" in mapping {'key': "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.tactic_name", 'object': 'x-ibm-ttp-tagging'}
ERROR: single quotes are not allowed in "key" in mapping {'key': "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.technique_name", 'object': 'x-ibm-ttp-tagging'}
ERROR: missing extension name in "key" in mapping {'key': 'x-ibm-ttp-tagging.extensions.name', 'object': 'x-ibm-ttp-tagging'}
```

If you use single quotes in a key, such as "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.tactic_name", you'll get something like this in your JSON:
```
          "type": "x-ibm-ttp-tagging",
          "extensions": {
            "'mitre-attack-ext'": {
```
Note the single quotes in `'mitre-attack-ext'` - that's not valid.  It should be "x-ibm-ttp-tagging.extensions.mitre-attack-ext.tactic_name", I believe.

A key like "x-ibm-ttp-tagging.extensions.name" is invalid because there's no extension name (there's already an entry for "x-ibm-ttp-tagging.extensions.'mitre-attack-ext'.technique_name" so I don't know what this entry is for).