### PR TITLE
Fixing from_stix_map Elastic_ecs Module

### DIFF
--- a/stix_shifter_modules/elastic_ecs/stix_translation/json/from_stix_map.json
+++ b/stix_shifter_modules/elastic_ecs/stix_translation/json/from_stix_map.json
@@ -110,7 +110,7 @@
       "parent_ref.x_thread_id": ["process.parent.thread.id"],
       "parent_ref.x_uptime": ["process.parent.uptime"],
       "parent_ref.cwd": ["process.parent.working_directory"],
-      "parent_ref.binary_ref.path": ["process.parent.executable"],
+      "parent_ref.binary_ref.name": ["process.parent.executable"],
       "parent_ref.binary_ref.parent_directory_ref.path": ["process.parent.executable"],
       "binary_ref.name": ["process.executable", "process.parent.executable"],
       "binary_ref.parent_directory_ref.path": ["process.executable", "process.parent.executable"],


### PR DESCRIPTION
Changed the from_stix_map mapping, in particular:

- there was a field named "process:parent_ref.binary_ref.path" that in STIX does not exists. Instead, it should be named "process:parent_ref.binary_ref.name".