### PR TITLE
Hided the API page size parameter view in CP4S console

### DIFF
--- a/stix_shifter_modules/crowdstrike_logscale/configuration/config.json
+++ b/stix_shifter_modules/crowdstrike_logscale/configuration/config.json
@@ -21,7 +21,8 @@
                 "min": 1000,
                 "max": 10000,
                 "type": "number",
-                "optional": true
+                "optional": true,
+                "hidden": true
             }
         }
     },

--- a/stix_shifter_modules/crowdstrike_logscale/stix_transmission/results_connector.py
+++ b/stix_shifter_modules/crowdstrike_logscale/stix_transmission/results_connector.py
@@ -67,6 +67,10 @@ class ResultsConnector(BaseJsonResultsConnector):
                 return_obj = await self.format_results(data, offset,total_records, first_iteration)
                 if (offset + len(return_obj['data'])) < self.api_client.result_limit:
                     return_obj['metadata'] = ResultsConnector.prepare_metadata(return_obj['data'], response_query_status_details)
+            else:
+                if not return_obj.get('success') and not return_obj.get('error'):
+                    return_obj['success'] = True
+                    return_obj['data'] = []
 
         except InvalidSearchIdException:
             return_obj = self.handle_api_exception(404,"Invalid Search Id")


### PR DESCRIPTION
Added hidden to true parameter in config.
Added changes in results connector to handle empty data.