### PR TITLE
Fixing the unit test failing.

### DIFF
--- a/stix_shifter_modules/azure_log_analytics/requirements.txt
+++ b/stix_shifter_modules/azure_log_analytics/requirements.txt
@@ -1,3 +1,4 @@
 azure-monitor-query==1.0.2
+numpy==1.26.4
 pandas==1.5.2
 jsonref==1.1.0

--- a/stix_shifter_modules/azure_log_analytics/requirements.txt
+++ b/stix_shifter_modules/azure_log_analytics/requirements.txt
@@ -1,4 +1,4 @@
 azure-monitor-query==1.0.2
-numpy==1.26.4
+numpy==1.24.4
 pandas==1.5.2
 jsonref==1.1.0


### PR DESCRIPTION
Numpy 2.0 released a week ago and broke our unit testing. Pinning the version to the latest 1.0 version to fix the issue.