### PR TITLE
Resolve cryptography vulnerability

### DIFF
--- a/deployment/ibm_cloud_pak_for_security/Dockerfile
+++ b/deployment/ibm_cloud_pak_for_security/Dockerfile
@@ -12,8 +12,8 @@ RUN microdnf update -y && rm -fr /var/cache/yum && \
 COPY ./bundle/ /opt/app/
 RUN chown -R 1001 /opt/app/
 RUN python3 -m pip install --upgrade pip
-RUN pip3 install 'cryptography==42.0.5'
-RUN pip3 install 'pyopenssl==24.1.0 '
+RUN pip3 install 'cryptography==44.0.2'
+RUN pip3 install 'pyopenssl==25.0.0 '
 
 USER 1001
 

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -12,7 +12,7 @@ flatten_json==0.1.14
 json-fix==1.0.0
 jsonmerge==1.9.2
 numpy==1.24.4
-pyOpenSSL==24.1.0
+pyOpenSSL==25.0.0
 python-dateutil==2.8.2
 stix2-matcher==3.0.0
 stix2-patterns==1.3.2


### PR DESCRIPTION
## Update cryptography Dependency for pyOpenSSL Compatibility  

### Summary  
This PR updates the required `cryptography` version to `44.0.2` and `pyOpenSSL` version to `25.0.0`.  

### Background  
OpenSSL is utilized for signing files when building connector images provided by IBM. Previously, `cryptography` was at version `42.0.5` and `pyOpenSSL` at `24.1.0`. The `pyOpenSSL` package has now been upgraded to version `25.0.0`, allowing the use of `cryptography` version `44.0.2`. This update addresses vulnerabilities present in earlier versions of `cryptography` that could affect the image signing process.  

### Changes  
- Upgrade `cryptography` from `42.0.5` to `44.0.2`.  
- Upgrade `pyOpenSSL` from `24.1.0` to `25.0.0`.  

### Impact  
This update mitigates security vulnerabilities in older `cryptography` versions while maintaining compatibility with the required OpenSSL functionality for image signing.  

### Testing  
- Verified successful image signing process with updated dependencies.  
- Ensured no regressions in the build process.  
