### PR TITLE
Resolve NumPy compatibility with Python 3.12

### DIFF
--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -11,7 +11,7 @@ flask==3.0.0
 flatten_json==0.1.14
 json-fix==1.0.0
 jsonmerge==1.9.2
-numpy==1.24.4
+numpy>=1.26,<1.27
 pyOpenSSL==25.0.0
 python-dateutil==2.8.2
 stix2-matcher==3.0.0

--- a/stix_shifter_modules/azure_log_analytics/requirements.txt
+++ b/stix_shifter_modules/azure_log_analytics/requirements.txt
@@ -1,4 +1,4 @@
 azure-monitor-query==1.0.2
-numpy==1.24.4
-pandas==1.5.2
+numpy>=1.26,<1.27
+pandas>=2.0.0
 jsonref==1.1.0


### PR DESCRIPTION
## Resolve NumPy dependency for version Python 3.12

### Summary  
Updating NumPy and by extension, Pandas, minimum versions specified in requirement files to allow for compatibility with Python version 3.12.

### Background  
NumPy version 1.24.4 was not compatible with Python version 3.12, we have bumped it to a version where it will gain compatibility with Python 3.12 without introducing breaking changes.

### Changes  
- Upgrade `NumPy` from `1.24.4` to at least `1.26` and not beyond `1.27`.  
- Upgrade `Pandas` from `1.5.2` to at least `2.0.0` for minimum compatibility with `NumPy v1.26`.  

### Impact  
NumPy compatibility will be within the Python version ranges of 3.8 to 3.12.

### Testing  
- Still covering all our grounds, do not merge.
