### PR TITLE
Bump urllib3 version to resolve security vulnerability

### DIFF
--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -17,5 +17,5 @@ python-dateutil==2.8.2
 stix2-matcher==3.0.0
 stix2-patterns==1.3.2
 xmltodict==0.13.0
-urllib3==1.26.19
+urllib3>=2.5.0,<3.0.0
 regex==2023.12.25

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -1,4 +1,4 @@
-aioboto3==12.1.0
+aioboto3>=14.0.0
 aiohttp-retry==2.8.3
 aiomysql==0.2.0
 antlr4-python3-runtime==4.8


### PR DESCRIPTION
## Bump urllib3 to v2.5.0 to resolve security vulnerability

### Summary  
Current version of stix-shifter is using 1.26.19 which is impacted by recently released CVEs. CVE‑2025‑50181 & CVE‑2025‑50182:
1. https://www.mend.io/vulnerability-database/CVE-2025-50182
2. https://www.mend.io/vulnerability-database/CVE-2025-50181

### Background  
urllib3 v1.26.19 is impacted by recently identified CVEs. It has been advised to bump to latest version 2.5.0.

### Changes  
- Upgrade `urllib3` from `1.26.19` to at least `2.5.0` with the requirement not to install past future versions at or beyond `3.0.0`.
- Upgrade `aioboto3` from `12.1.0` to at least `14.0.0` for compatibility with `urllib v2.5.0`, due to it's transient dependency on aiobotocore, which is dependent on botocore, which is dependent on urllib of a specified version.  

### Impact  
urllib3 drops support for Python 3.8 as of 2.0.0, so by extension our requirements would be dropping support for Python 3.8. We would still support Python 3.9-3.12 for now.

### Testing  
- Still covering all our grounds, do not merge.
