### PR TITLE
Set Python 3.10 as Project's Minimum Python Version

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python generate_requirements.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@ We have started this changelogs from version 4.0.0. So, changes on previously re
 ### Dependency update:
 *List the dependecy upgrade or downgrade.*
 
+## 8.0.0 (2025-10-30)
+
+### Breaking changes:
+*  **Minimum Python version raised to 3.10**; Python 3.9 support removed due to EOL.
+*  Support now officially targets Python **3.10 – 3.12**.
+
+### Deprecations:
+*  Python **3.9 and below** are no longer supported.
+
+### Changes:
+*  CI updated to remove Python 3.9 and add coverage for Python 3.11 and 3.12.
+*  Updated core and module requirements to support modern Python versions.
+
+### Fixes:
+*  Resolved compatibility issues with **NumPy on Python 3.12**.
+
+### Dependency update:
+*  Bump **NumPy** from `1.24.4` → `>=1.26,<1.27`.
+*  Bump **Pandas** (Azure Log Analytics module) from `1.5.2` → `>=2.0.0`.
+*  Bump **urllib3** from `1.26.19` → `>=2.5.0,<3.0.0` to address:
+   * CVE-2025-50181  
+   * CVE-2025-50182
+*  Bump **aioboto3** from `12.1.0` → `>=15.0.0` to ensure compatibility with `urllib3 >=2.5.0`.
+
+--------------------------------------
+
 ## 7.1.4 – 7.1.6 (2025-06-18 – 2025-08-15)
 _Retagged/rebuilt for updated base images. No functional changes since 7.1.3._
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,35 @@ We have started this changelogs from version 4.0.0. So, changes on previously re
 ### Dependency update:
 *List the dependecy upgrade or downgrade.*
 
+## 7.1.4 – 7.1.6 (2025-06-18 – 2025-08-15)
+_Retagged/rebuilt for updated base images. No functional changes since 7.1.3._
+
+--------------------------------------
+
+## 7.1.3 (2025-04-02)
+
+### Breaking changes:
+*  Minimum version must be 3.9 to resolve this security vulnerability. [#1744](https://github.com/opencybersecurityalliance/stix-shifter/pull/1744)
+
+### Deprecations:
+
+### Changes:
+
+### Fixes:
+*  Updating the code coverage version to resolve the failure. [#1743](https://github.com/opencybersecurityalliance/stix-shifter/pull/1743)
+
+### Dependency update:
+*  Bump azure-identity from 1.16.1 to 1.19.0 in /stix_shifter [#1740](https://github.com/opencybersecurityalliance/stix-shifter/pull/1740)
+*  Bump mysql-connector-python from 8.0.25 to 9.1.0 in /stix_shifter_modules/mysql [#1742](https://github.com/opencybersecurityalliance/stix-shifter/pull/1742)
+*  Resolve cryptography vulnerability [#1756](https://github.com/opencybersecurityalliance/stix-shifter/pull/1756)
+
+--------------------------------------
+
+## 7.1.2 (2025-03-12)
+_Retagged/rebuilt for updated base images. No functional changes since 7.1.1._
+
+--------------------------------------
+
 ## 7.1.1 (2024-09-19)
 
 ### Breaking changes:

--- a/bundle_validator/README.md
+++ b/bundle_validator/README.md
@@ -6,7 +6,7 @@ You can easily validate your stix bundle file by following the below steps:
 
 The following needs to be installed on your local machine:
 
-* Python 3.9 or greater
+* Python 3.10 or greater
 * git
 * [`stix2-validator`](https://github.com/oasis-open/cti-stix-validator) python library
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ The recommended method for installing stix-shifter is via pip. Two prerequisite 
 
 ### Dependencies
 
-STIX-shifter requries Python 3.9 or greater. See the [requirements file](../stix_shifter/requirements.txt) for library dependencies. 
+STIX-shifter requries Python 3.10 or greater. See the [requirements file](../stix_shifter/requirements.txt) for library dependencies. 
 
 ## Usage
 

--- a/docs/lab/cli_lab.ipynb
+++ b/docs/lab/cli_lab.ipynb
@@ -161,7 +161,7 @@
     "\n",
     "### Prerequisites\n",
     "\n",
-    "* Python 3.9 or greater\n",
+    "* Python 3.10 or greater\n",
     "* pip\n",
     "* git\n",
     "* `virtualenv` python library\n",
@@ -187,7 +187,7 @@
     "### 3. Install and activate a Python virtual environment and upgrade pip\n",
     "\n",
     "```bash\n",
-    "python3.9 -m venv labenv\n",
+    "python3.10 -m venv labenv\n",
     "source labenv/bin/activate\n",
     "python3 -m pip install --upgrade pip\n",
     "```\n",
@@ -291,6 +291,12 @@
     "### STIX Identity Object\n",
     "The identity object represents the data source the STIX results are taken from. As we will see, the identity object is passed into some of the CLI commands so that STIX-shifter can prepend it to the top of the bundle of STIX results."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd8e8ffb",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",

--- a/docs/lab/cli_lab.ipynb
+++ b/docs/lab/cli_lab.ipynb
@@ -293,12 +293,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "bd8e8ffb",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "8867db72",

--- a/docs/lab/connector_coding_lab.md
+++ b/docs/lab/connector_coding_lab.md
@@ -7,7 +7,7 @@ This is a hands-on lab to start implementing a connector module in STIX-shifter 
 
 * GitHub account
 * Basic knowledge of git such as forking, committing, branching, pulling, and merging.
-* Working knowledge of the Python programming language. This lab will use Python 3.9
+* Working knowledge of the Python programming language. This lab will use Python 3.10
 * An IDE to write Python code, such as VS Code.
 * Knowledge of the data source API that includes API request, response, datatype and schema.
 * Knowledge of STIX 2.0. To learn about STIX Cyber Observable Objects, see the [STIX 2.0](https://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part4-cyber-observable-objects.html) specification.
@@ -18,9 +18,9 @@ This is a hands-on lab to start implementing a connector module in STIX-shifter 
 ### 3. Make sure you are in the `stix-shifter/` parent directory
 ### 4. Create a python virtual environment with required depedencies in the terminal
 
-**Create Python3.9 virtual environment:**
+**Create Python3.10 virtual environment:**
 ```bash
-virtualenv -p python3.9 virtualenv && source virtualenv/bin/activate
+virtualenv -p python3.10 virtualenv && source virtualenv/bin/activate
 ```
 
 **Upgrade pip(optional):**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,18 @@
 -r requirements.txt
-astroid==2.12.12
-autopep8==1.3.4
-coverage==6.5.0
+astroid>=2.15.0,<3.0.0
+autopep8>=2.0.4,<3.0.0
+coverage>=7.0.0,<8.0.0
 debugpy-run
-flake8==3.5.0
-freezegun==1.2.2
-isort==4.3.4
-lazy-object-proxy==1.8.0
-mccabe==0.6.1
-more-itertools==4.1.0
-pluggy==1.0.0
-pycodestyle==2.3.1
-pyflakes==1.6.0
-pylint==2.15.5
-pytest==7.2.0
-requests_mock==1.7.0
-six==1.16.0
-wrapt==1.14.1
+flake8>=7.0.0,<8.0.0
+freezegun>=1.2.2,<2.0.0
+isort>=5.12.0,<6.0.0
+lazy-object-proxy>=1.8.0,<2.0.0
+mccabe>=0.6.1,<1.0.0
+more-itertools>=10.7.0,<11.0.0
+pluggy>=1.0.0,<2.0.0
+pylint>=2.15.5,<3.0.0
+pytest>=7.2.0,<8.0.0
+requests_mock>=1.7.0,<2.0.0
+six>=1.16.0,<2.0.0
+wrapt>=1.14.1,<2.0.0
+# pycodestyle and pyflakes left unpinned so flake8 controls versions

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ import os
 import subprocess
 import sys
 
-if sys.version_info.major == 3 and sys.version_info.minor > 7:
-    # good
+# Check Python version is or greater than 3.10
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
     print(sys.version)
 else:
-    print("Error: stix-shifter requires python 3.9 or greater")
+    print("Error: stix-shifter requires python 3.10 or greater")
     exit(1)
 
 
@@ -165,8 +165,8 @@ for project_name in projects.keys():
         # https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'classifiers': [  # Optional
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
         ],
         'keywords': 'datasource stix translate transform transmit',  # Optional
         'packages': packages,  # Required

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -17,5 +17,5 @@ python-dateutil==2.8.2
 stix2-matcher==3.0.0
 stix2-patterns==1.3.2
 xmltodict==0.13.0
-urllib3==1.26.19
+urllib3>=2.5.0,<3.0.0
 regex==2023.12.25

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -1,4 +1,4 @@
-aioboto3>=14.0.0
+aioboto3==15.0.0
 aiohttp-retry==2.8.3
 aiomysql==0.2.0
 antlr4-python3-runtime==4.8
@@ -11,7 +11,7 @@ flask==3.0.0
 flatten_json==0.1.14
 json-fix==1.0.0
 jsonmerge==1.9.2
-numpy==1.24.4
+numpy>=1.26,<1.27
 pyOpenSSL==25.0.0
 python-dateutil==2.8.2
 stix2-matcher==3.0.0

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -1,4 +1,4 @@
-aioboto3==12.1.0
+aioboto3>=14.0.0
 aiohttp-retry==2.8.3
 aiomysql==0.2.0
 antlr4-python3-runtime==4.8

--- a/stix_shifter_modules/azure_log_analytics/requirements.txt
+++ b/stix_shifter_modules/azure_log_analytics/requirements.txt
@@ -1,4 +1,4 @@
 azure-monitor-query==1.0.2
-numpy==1.24.4
+numpy>=1.26,<1.27
 pandas==1.5.2
 jsonref==1.1.0


### PR DESCRIPTION
## Set Python 3.10 as the Minimum Supported Python Version  

### Summary  

- **Drop Python 3.9 support**  
  Python 3.9 will reach end-of-life in October 2025. This PR removes support for 3.9 and sets **Python 3.10** as the minimum supported version. This ensures the project remains maintainable, secure, and aligned with modern package support.  

- **Resolve NumPy incompatibility with Python 3.12**  
  The current NumPy version is not compatible with Python 3.12. The dependency is upgraded to maintain compatibility across supported Python versions.  

- **Address `urllib3` vulnerabilities**  
  `urllib3` v1.26.19 (currently in use) is affected by CVE-2025-50181 and CVE-2025-50182.  
  - [CVE-2025-50182](https://www.mend.io/vulnerability-database/CVE-2025-50182)  
  - [CVE-2025-50181](https://www.mend.io/vulnerability-database/CVE-2025-50181)  

---

### Changes  

1. **Python Version Support**  
   - Set minimum supported version to **3.10**.  
   - Remove Python 3.9 from the CI test matrix.  
   - Extend CI test coverage to **3.11** and **3.12**.  

2. **NumPy & Pandas Compatibility**  
   - Upgrade **NumPy** from `1.24.4` → `>=1.26,<1.27`.  
   - In `stix_shifter_modules/azure_log_analytics/requirements.txt`, upgrade **Pandas** from `1.5.2` → `>=2.0.0` (required for NumPy 1.26+).  

3. **urllib3 & Related Dependencies**  
   - Upgrade **urllib3** from `1.26.19` → `>=2.5.0,<3.0.0`.  
   - Upgrade **aioboto3** from `12.1.0` → `>=15.0.0`, for compatibility with `urllib3 v2.5.0` (via `aiobotocore → botocore → urllib3`).  

---

### Impact  

- Drop support for Python **3.9 and below**.  
- Officially support **Python 3.10 – 3.12**.  
- Newer Python versions have not yet been validated, but the goal is to support all currently released stable Python versions.  

---

### Testing  

- CI covers Python 3.10, 3.11, and 3.12. (and passing)  
- Dependencies verified to be working. Changelogs cross referenced and transient dependencies inspected via `pipdeptree`.
- `Requirements.txt` confirmed to install across Python 3.10, 3.11, 3.12.
- Manual tests performed on select STIX-shifter modules.
