### PR TITLE
Update python dateutil to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ We have started this changelogs from version 4.0.0. So, changes on previously re
 ### Dependency update:
 *List the dependecy upgrade or downgrade.*
 
+## 8.0.1 (2025-10-30)
+
+### Breaking changes:
+* None
+
+### Deprecations:
+* None
+
+### Changes:
+* Updated the supported minimum version of **python-dateutil** to `2.9.0` to improve compatibility with modern Python packages and Python versions 3.10-3.12.
+
+### Fixes:
+* Resolved dependency conflict with projects requiring **python-dateutil >=2.9.0**.
+
+### Dependency update:
+* Bump **python-dateutil** from `2.8.2` → `>=2.9.0,<3.0.0`
+
+--------------------------------------
+
 ## 8.0.0 (2025-10-30)
 
 ### Breaking changes:

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -13,7 +13,7 @@ json-fix==1.0.0
 jsonmerge==1.9.2
 numpy>=1.26,<1.27
 pyOpenSSL==25.0.0
-python-dateutil==2.8.2
+python-dateutil>=2.9.0,<3.0.0
 stix2-matcher==3.0.0
 stix2-patterns==1.3.2
 xmltodict==0.13.0


### PR DESCRIPTION
Update `python-dateutil` to 2.9.0

This PR updates the minimum required version of `python-dateutil` from `2.8.2` to `>=2.9.0,<3.0.0`.

This change:
- Improves compatibility with modern Python packages and ensures support for Python 3.10–3.12.
- Resolves dependency conflicts with projects that require `python-dateutil >=2.9.0`.
- Does not introduce any functional changes in stix-shifter; it is purely a dependency update.

Users pinned to `python-dateutil 2.8.2` may need to upgrade.
