### PR TITLE
Increase default connection timeout to 10 seconds

### DIFF
--- a/stix_shifter_utils/stix_transmission/utils/RestApiClientAsync.py
+++ b/stix_shifter_utils/stix_transmission/utils/RestApiClientAsync.py
@@ -15,7 +15,7 @@ from stix_shifter_utils.utils import logger
 # This is a simple HTTP client that can be used to access the REST API
 
 RETRY_MAX_DEFAULT = 1
-CONNECT_TIMEOUT_DEFAULT = 2
+CONNECT_TIMEOUT_DEFAULT = 10
 
 
 class InterruptableThread(threading.Thread):


### PR DESCRIPTION
Increase the `CONNECT_TIMEOUT_DEFAULT` from `2` to `10` as we have had a number of clients who's requests are timing out.  I understand this value can be overridden with the `STIXSHIFTER_CONNECT_TIMEOUT` environment variable however I think `2` is probably too short by default and should be increased.