### PR TITLE
Upgrade aiomysql to 0.3.2

### DIFF
--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -1,6 +1,6 @@
 aioboto3==15.0.0
 aiohttp-retry==2.8.3
-aiomysql==0.2.0
+aiomysql>=0.3.2,<0.4.0
 antlr4-python3-runtime==4.8
 asyncio==3.4.3
 asynctest==0.13.0


### PR DESCRIPTION
Resolves vulnerability `CVE-2025-62611`.
https://nvd.nist.gov/vuln/detail/CVE-2025-62611
