### PR TITLE
Add local CI test script for contributors

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,8 +40,6 @@ To test a specific connector module:
 pytest stix_shifter_modules/<module-name>/tests/ -vv
 ```
 
-For more development commands and guidance, see [CLAUDE.md](../CLAUDE.md).
-
 ## <a id="feedback">Feedback</a>
 
 Questions or comments about the OCA's activities may be composed as GitHub issues or comments or may be directed to the project's general email list at oca@lists.oasis-open-projects.org. General questions about OASIS Open Projects may be directed to OASIS staff at op-admin@lists.oasis-open-projects.org

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,6 +6,42 @@ The Open Cybersecurity Alliance (OCA) is an [OASIS Open Project](https://oasis-o
 
 Participation is expected to be consistent with the [Code of Conduct](https://github.com/opencybersecurityalliance/oca-admin/blob/master/CODE_OF_CONDUCT.md), the [licenses](https://github.com/opencybersecurityalliance/oca-admin/blob/master/LICENSE.md), and the acceptance of our [individual Contributor License Agreement](https://cla-assistant.io/opencybersecurityalliance/oasis-open-project), generally at the time of first contribution.
 
+## <a id="development">Development Workflow</a>
+
+### Running Tests Locally
+
+Before submitting a pull request, run the CI test suite locally to ensure your changes pass all checks:
+
+```bash
+# Quick test with your current Python version
+./run_ci_tests.sh
+
+# Comprehensive test across Python 3.10, 3.11, and 3.12 (requires pyenv)
+./run_ci_tests.sh --all-versions
+```
+
+The CI script runs the same checks as GitHub Actions:
+1. Generates consolidated requirements
+2. Installs dependencies
+3. Runs flake8 linting (syntax errors and style warnings)
+4. Executes the full pytest test suite
+
+**Note**: The `--all-versions` flag requires Python 3.10, 3.11, and 3.12 to be installed via pyenv. Install missing versions with:
+```bash
+pyenv install 3.11.11
+pyenv install 3.12.8
+```
+
+### Testing Individual Connectors
+
+To test a specific connector module:
+
+```bash
+pytest stix_shifter_modules/<module-name>/tests/ -vv
+```
+
+For more development commands and guidance, see [CLAUDE.md](../CLAUDE.md).
+
 ## <a id="feedback">Feedback</a>
 
 Questions or comments about the OCA's activities may be composed as GitHub issues or comments or may be directed to the project's general email list at oca@lists.oasis-open-projects.org. General questions about OASIS Open Projects may be directed to OASIS staff at op-admin@lists.oasis-open-projects.org

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Replicate GitHub Actions CI workflow locally
+# Usage:
+#   ./run_ci_tests.sh              # Test with current Python version (fast)
+#   ./run_ci_tests.sh --all-versions  # Test with Python 3.10, 3.11, 3.12 (comprehensive)
+
+set -e  # Exit on error
+
+# Parse arguments
+ALL_VERSIONS=false
+if [[ "$1" == "--all-versions" ]]; then
+    ALL_VERSIONS=true
+fi
+
+# Python versions to test (matches GitHub Actions matrix)
+PYTHON_VERSIONS=("3.10" "3.11" "3.12")
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to run CI tests for a specific Python version
+run_tests_for_version() {
+    local python_cmd=$1
+    local version_label=$2
+    local venv_path=$3
+
+    echo -e "${BLUE}================================${NC}"
+    echo -e "${BLUE}Testing with Python ${version_label}${NC}"
+    echo -e "${BLUE}================================${NC}"
+    echo ""
+
+    # Create and activate virtual environment if specified
+    if [[ -n "$venv_path" ]]; then
+        echo "🔧 Creating virtual environment: ${venv_path}"
+        $python_cmd -m venv "$venv_path"
+        source "${venv_path}/bin/activate"
+        echo "✓ Activated ${venv_path}"
+        echo ""
+    fi
+
+    echo "🔧 Generating requirements..."
+    $python_cmd generate_requirements.py
+
+    echo ""
+    echo "📦 Installing dependencies..."
+    pip install --upgrade pip setuptools wheel
+    pip install -r requirements-dev.txt
+
+    echo ""
+    echo "🔍 Linting: Checking for syntax errors (critical)..."
+    pip install --upgrade flake8
+    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics \
+        --exclude='virtualenv,venv,.venv,build,dist,.git,.pytest_cache,__pycache__,virtualenv_ci_*'
+
+    echo ""
+    echo "⚠️  Linting: Checking for style warnings..."
+    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics \
+        --exclude='virtualenv,venv,.venv,build,dist,.git,.pytest_cache,__pycache__,virtualenv_ci_*'
+
+    echo ""
+    echo "🧪 Running all tests with pytest..."
+    pip install pytest
+    pytest -vv
+
+    # Deactivate virtual environment if we created one
+    if [[ -n "$venv_path" ]]; then
+        deactivate
+        echo ""
+        echo -e "${GREEN}✓ Python ${version_label} tests completed successfully${NC}"
+    fi
+
+    echo ""
+}
+
+# Function to check if a Python version is available
+check_python_version() {
+    local version=$1
+    if command -v python${version} &> /dev/null; then
+        return 0
+    elif pyenv versions --bare | grep -q "^${version}"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to get Python command for a version
+get_python_command() {
+    local version=$1
+    if command -v python${version} &> /dev/null; then
+        echo "python${version}"
+    elif pyenv versions --bare | grep -q "^${version}"; then
+        # Use pyenv to get the full version (e.g., 3.10.14)
+        local full_version=$(pyenv versions --bare | grep "^${version}" | head -1)
+        echo "$(pyenv root)/versions/${full_version}/bin/python"
+    else
+        echo ""
+    fi
+}
+
+# Main execution
+if [[ "$ALL_VERSIONS" == true ]]; then
+    echo -e "${YELLOW}Running CI tests for all Python versions (3.10, 3.11, 3.12)${NC}"
+    echo -e "${YELLOW}This will take several minutes...${NC}"
+    echo ""
+
+    # Check which versions are available
+    AVAILABLE_VERSIONS=()
+    MISSING_VERSIONS=()
+
+    for version in "${PYTHON_VERSIONS[@]}"; do
+        if check_python_version "$version"; then
+            AVAILABLE_VERSIONS+=("$version")
+        else
+            MISSING_VERSIONS+=("$version")
+        fi
+    done
+
+    # Warn about missing versions
+    if [[ ${#MISSING_VERSIONS[@]} -gt 0 ]]; then
+        echo -e "${YELLOW}⚠️  Warning: The following Python versions are not installed:${NC}"
+        for version in "${MISSING_VERSIONS[@]}"; do
+            echo -e "${YELLOW}   - Python ${version}${NC}"
+        done
+        echo -e "${YELLOW}   Install with: pyenv install ${MISSING_VERSIONS[0]}${NC}"
+        echo ""
+    fi
+
+    # Exit if no versions available
+    if [[ ${#AVAILABLE_VERSIONS[@]} -eq 0 ]]; then
+        echo -e "${RED}Error: No Python versions available for testing${NC}"
+        exit 1
+    fi
+
+    # Run tests for each available version
+    FAILED_VERSIONS=()
+    for version in "${AVAILABLE_VERSIONS[@]}"; do
+        python_cmd=$(get_python_command "$version")
+        venv_path="virtualenv_ci_${version}"
+
+        if run_tests_for_version "$python_cmd" "$version" "$venv_path"; then
+            echo -e "${GREEN}✓ Python ${version} passed${NC}"
+        else
+            echo -e "${RED}✗ Python ${version} failed${NC}"
+            FAILED_VERSIONS+=("$version")
+        fi
+
+        # Clean up virtual environment
+        rm -rf "$venv_path"
+        echo ""
+    done
+
+    # Final summary
+    echo -e "${BLUE}================================${NC}"
+    echo -e "${BLUE}Test Summary${NC}"
+    echo -e "${BLUE}================================${NC}"
+    echo "Tested versions: ${#AVAILABLE_VERSIONS[@]}"
+    echo "Passed: $((${#AVAILABLE_VERSIONS[@]} - ${#FAILED_VERSIONS[@]}))"
+    echo "Failed: ${#FAILED_VERSIONS[@]}"
+
+    if [[ ${#FAILED_VERSIONS[@]} -gt 0 ]]; then
+        echo -e "${RED}Failed versions: ${FAILED_VERSIONS[*]}${NC}"
+        exit 1
+    else
+        echo -e "${GREEN}✅ All Python versions passed!${NC}"
+    fi
+
+else
+    # Single version mode - use current Python
+    echo -e "${YELLOW}Running CI tests with current Python version${NC}"
+    echo -e "${YELLOW}Use --all-versions flag to test against Python 3.10, 3.11, 3.12${NC}"
+    echo ""
+
+    current_version=$(python --version | cut -d' ' -f2)
+    run_tests_for_version "python" "$current_version" ""
+
+    echo -e "${GREEN}✅ All CI checks passed!${NC}"
+fi


### PR DESCRIPTION
## Summary

This PR adds tooling to help contributors validate their changes locally before submitting pull requests, reducing CI failures and improving the development workflow.

## Changes

### 1. Local CI Test Script (`run_ci_tests.sh`)

A new script that replicates the GitHub Actions CI workflow locally:

**Features:**
- **Fast mode (default)**: Tests with current Python version (~30 seconds)
  ```bash
  ./run_ci_tests.sh
  ```
- **Comprehensive mode**: Tests across Python 3.10, 3.11, 3.12
  ```bash
  ./run_ci_tests.sh --all-versions
  ```

**What it tests:**
1. Generates consolidated requirements
2. Installs dependencies
3. Runs flake8 linting (critical syntax errors)
4. Runs flake8 style checks (warnings only)
5. Executes full pytest test suite (2300+ tests)

**Implementation details:**
- Creates isolated virtual environments (`virtualenv_ci_*`) matching existing `.gitignore` patterns
- Automatically detects available Python versions via pyenv
- Provides colored output and detailed error reporting
- Cleans up virtual environments after testing

### 2. Updated Contributor Documentation (`docs/CONTRIBUTING.md`)

Added a "Development Workflow" section with:
- Instructions for running CI tests locally
- Guidance on multi-version testing
- Commands for installing required Python versions
- Reference to detailed development documentation

## Benefits

- **Faster development cycle**: Contributors can catch issues locally before pushing
- **Reduced CI load**: Fewer failed CI runs from preventable errors
- **Better contributor experience**: Clear guidance on testing requirements
- **Matches GitHub Actions**: Same checks, same results, locally

## Testing

Verified the script works correctly:
- ✅ Single-version mode completes successfully
- ✅ Properly excludes virtual environments from linting
- ✅ All 2309 tests pass
- ✅ Virtual environment naming matches `.gitignore` patterns

## Notes

This PR contains only documentation and tooling improvements - no changes to production code. It can be reviewed and merged independently of other PRs.