### PR TITLE
Update pyOpenSSL version to 25.3.0

### DIFF
--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -12,7 +12,7 @@ flatten_json==0.1.14
 json-fix==1.0.0
 jsonmerge==1.9.2
 numpy>=1.26,<1.27
-pyOpenSSL==25.0.0
+pyOpenSSL==25.3.0
 python-dateutil>=2.9.0,<3.0.0
 stix2-matcher==3.0.0
 stix2-patterns==1.3.2


### PR DESCRIPTION
Resolves [CVE-2026-26007](https://nvd.nist.gov/vuln/detail/CVE-2026-26007)