### PR TITLE
Remove unused NumPy dependency from requirements.

### DIFF
--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -11,7 +11,6 @@ flask==3.1.2
 flatten_json==0.1.14
 json-fix==1.0.0
 jsonmerge==1.9.2
-numpy>=2.1.0,<3.0.0
 pyOpenSSL==25.3.0
 python-dateutil>=2.9.0,<3.0.0
 stix2-matcher==3.0.0


### PR DESCRIPTION
NumPy is only used by the Azure connector for one import of Pandas where it is defined in it's own requirements.

Not sure why it is declared redundantly in the main requirements.txt file where it may cause issues for integrators, therefore it is being removed.