### PR TITLE
Upgrade Cryptography & PyOpenSSL References

### DIFF
--- a/deployment/ibm_cloud_pak_for_security/Dockerfile
+++ b/deployment/ibm_cloud_pak_for_security/Dockerfile
@@ -12,8 +12,7 @@ RUN microdnf update -y && rm -fr /var/cache/yum && \
 COPY ./bundle/ /opt/app/
 RUN chown -R 1001 /opt/app/
 RUN python3 -m pip install --upgrade pip
-RUN pip3 install 'cryptography==44.0.2'
-RUN pip3 install 'pyopenssl==25.0.0 '
+RUN pip3 install 'cryptography>=49.0.0' 'pyopenssl>=26.3.0'
 
 USER 1001
 

--- a/stix_shifter/requirements.txt
+++ b/stix_shifter/requirements.txt
@@ -11,7 +11,7 @@ flask==3.1.3
 flatten_json==0.1.14
 json-fix==1.0.2
 jsonmerge==1.9.2
-pyOpenSSL==26.0.0
+pyOpenSSL>=26.3.0
 python-dateutil>=2.9.0,<3.0.0
 stix2-matcher==3.0.0
 stix2-patterns==2.1.2


### PR DESCRIPTION
### Description

- Upgrades cryptography & pyopenssl reference in deployment script.
- Additionally bumps pyopenssl requirement from a hard-pin to a more suitable and up-to-date lower-bound pin.

Resolves references showing up in scans due to open CVE against current cryptography version.

As a bonus, migrating the PyOpenSSL dependency from a hard-pin to a lower-bound pin enhances dependency flexibility, so as to enable better accommodation to consumers.

---

### Validation

pip3 install 'cryptography>=49.0.0' 'pyopenssl>=26.3.0' --dry-run 2>&1

