### PR TITLE
Fix QRadar LIKE translation for exact vs substring matches

### DIFF
--- a/stix_shifter_modules/qradar/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/qradar/stix_translation/query_constructor.py
@@ -53,7 +53,11 @@ class AqlQueryStringPatternTranslator:
 
     @staticmethod
     def _format_like(value) -> str:
-        return "'%{value}%'".format(value=value)
+        return "'{}'".format(value)
+
+    @staticmethod
+    def _format_substring_like(value) -> str:
+        return "'%{}%'".format(value)
 
     @staticmethod
     def _escape_value(value, comparator=None) -> str:
@@ -108,35 +112,37 @@ class AqlQueryStringPatternTranslator:
         mapped_fields_count = 1 if is_reference_value else len(mapped_fields_array)
 
         for mapped_field in mapped_fields_array:
+            field_comparator = comparator
+            field_value = value
             # if its a set operator() query construction will be different.
             if expression.object_path in FILTERING_DATA_TYPES.keys():
-                comparison_string += "{}({})".format(FILTERING_DATA_TYPES[expression.object_path], value)
+                comparison_string += "{}({})".format(FILTERING_DATA_TYPES[expression.object_path], field_value)
             elif expression.comparator == ComparisonComparators.IsSubSet:
-                comparison_string += comparator + "(" + "'" + value + "'," + mapped_field + ")"
+                comparison_string += field_comparator + "(" + "'" + field_value + "'," + mapped_field + ")"
             elif is_reference_value:
-                parsed_reference = self._parse_reference(self, stix_field, value_type, mapped_field, value, comparator)
+                parsed_reference = self._parse_reference(self, stix_field, value_type, mapped_field, field_value, field_comparator)
                 if not parsed_reference:
                     continue
                 comparison_string += parsed_reference
             # For [ipv4-addr:value = <CIDR value>]
             elif bool(re.search(observable.REGEX['ipv4_cidr'], str(expression.value))):
-                comparison_string += "INCIDR(" + value + "," + mapped_field + ")"
+                comparison_string += "INCIDR(" + field_value + "," + mapped_field + ")"
             elif (expression.object_path == 'ipv4-addr:value'
                   or expression.object_path == 'ipv6-addr:value'
                   or expression.object_path == 'network-traffic:dst_ref.value'
                   or expression.object_path == 'network-traffic:src_ref.value') \
                   and expression.comparator == ComparisonComparators.Like:
                       comparison_string += "str({mapped_field}) {comparator} {value}".format(mapped_field=mapped_field,
-                                                                                             comparator=comparator,
-                                                                                             value=value)
+                                                                                             comparator=field_comparator,
+                                                                                             value=field_value)
             else:
                 # There's no aql field for domain-name. using Like operator to find domian name from the url
-                if self.dmm.dialect == 'events' and mapped_field == 'dnsdomainname' and comparator != ComparisonComparators.Like:
-                    comparator = self.comparator_lookup["ComparisonComparators.Like"]
-                    value = self._format_like(expression.value)
+                if self.dmm.dialect == 'events' and mapped_field == 'dnsdomainname' and expression.comparator != ComparisonComparators.Like:
+                    field_comparator = self.comparator_lookup["ComparisonComparators.Like"]
+                    field_value = AqlQueryStringPatternTranslator._format_substring_like(expression.value)
 
                 comparison_string += "{mapped_field} {comparator} {value}".format(
-                    mapped_field=mapped_field, comparator=comparator, value=value)
+                    mapped_field=mapped_field, comparator=field_comparator, value=field_value)
 
             if (mapped_fields_count > 1):
                 comparison_string += " OR "
@@ -237,7 +243,7 @@ class AqlQueryStringPatternTranslator:
         elif expression.comparator == ComparisonComparators.Equal or expression.comparator == ComparisonComparators.NotEqual:
             # Should be in single-quotes
             value = self._format_equality(expression.value)
-        # '%' -> '*' wildcard, '_' -> '?' single wildcard
+        # Pass STIX LIKE wildcards (% and _) through unchanged
         elif expression.comparator == ComparisonComparators.Like and not (expression.object_path == 'artifact:payload_bin'):
             value = self._format_like(expression.value)
         else:

--- a/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
+++ b/stix_shifter_modules/qradar/tests/stix_translation/qradar_stix_to_aql/test_qradar_events_stix_to_query.py
@@ -247,7 +247,7 @@ class TestQueryTranslator(unittest.TestCase, object):
     def test_domainname_query(self):
         stix_pattern = "[domain-name:value = 'example.com']"
         query = _translate_query(stix_pattern)
-        where_statement = "WHERE (dnsdomainname LIKE '%example.com%' OR UrlHost LIKE '%example.com%') {} {}".format(default_limit, default_time)
+        where_statement = "WHERE (dnsdomainname LIKE '%example.com%' OR UrlHost = 'example.com') {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_generic_filehash_query(self):
@@ -313,7 +313,7 @@ class TestQueryTranslator(unittest.TestCase, object):
         search_string = 'example.com'
         stix_pattern = "[url:value LIKE '{}']".format(search_string)
         query = _translate_query(stix_pattern)
-        where_statement = "WHERE url LIKE '%{0}%' {1} {2}".format(search_string, default_limit, default_time)
+        where_statement = "WHERE url LIKE '{0}' {1} {2}".format(search_string, default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_payload_string_matching_with_LIKE(self):
@@ -372,10 +372,48 @@ class TestQueryTranslator(unittest.TestCase, object):
         stix_pattern = "([ipv4-addr:value = '192.168.1.2'] OR [url:value LIKE '%.example.com']) START t'2020-09-11T13:00:52.000Z' STOP t'2020-09-11T13:59:04.000Z'"
         query = _translate_query(stix_pattern)
         where_statement_01 = "WHERE (sourceip = '192.168.1.2' OR destinationip = '192.168.1.2' OR identityip = '192.168.1.2') limit 10000 START 1599829252000 STOP 1599832744000"
-        where_statement_02 = "WHERE url LIKE '%%.example.com%' limit 10000 START 1599829252000 STOP 1599832744000"
+        where_statement_02 = "WHERE url LIKE '%.example.com' limit 10000 START 1599829252000 STOP 1599832744000"
         assert len(query['queries']) == 2
         assert query['queries'][0] == selections + from_statement + where_statement_01
         assert query['queries'][1] == selections + from_statement + where_statement_02
+
+    def test_LIKE_operator_prefix_wildcard(self):
+        stix_pattern = "[url:value LIKE 'S_on%']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE url LIKE 'S_on%' {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_LIKE_operator_suffix_wildcard(self):
+        stix_pattern = "[url:value LIKE '%.example.com']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE url LIKE '%.example.com' {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_domainname_equality_field_order_independence(self):
+        from stix_shifter_modules.qradar.stix_translation.query_constructor import AqlQueryStringPatternTranslator
+        from stix_shifter_utils.stix_translation.src.patterns.pattern_objects import ComparisonExpression, ComparisonComparators
+
+        class MockSelf:
+            class dmm:
+                dialect = 'events'
+            comparator_lookup = {"ComparisonComparators.Like": "LIKE"}
+
+            @staticmethod
+            def _is_reference_value(stix_field):
+                return AqlQueryStringPatternTranslator._is_reference_value(stix_field)
+
+        expression = ComparisonExpression('domain-name:value', 'example.com', ComparisonComparators.Equal)
+        mock_self = MockSelf()
+        value = "'example.com'"
+        comparator = "="
+
+        result_default = AqlQueryStringPatternTranslator._parse_mapped_fields(
+            mock_self, expression, value, comparator, 'value', ['dnsdomainname', 'UrlHost'])
+        assert result_default == "dnsdomainname LIKE '%example.com%' OR UrlHost = 'example.com'"
+
+        result_reversed = AqlQueryStringPatternTranslator._parse_mapped_fields(
+            mock_self, expression, value, comparator, 'value', ['UrlHost', 'dnsdomainname'])
+        assert result_reversed == "UrlHost = 'example.com' OR dnsdomainname LIKE '%example.com%'"
 
     def test_registry_search(self):
         stix_pattern = "[windows-registry-key:values[*].name = 'abcd']"

--- a/stix_shifter_modules/qradar_perf_test/stix_translation/query_constructor.py
+++ b/stix_shifter_modules/qradar_perf_test/stix_translation/query_constructor.py
@@ -53,7 +53,11 @@ class AqlQueryStringPatternTranslator:
 
     @staticmethod
     def _format_like(value) -> str:
-        return "'%{value}%'".format(value=value)
+        return "'{}'".format(value)
+
+    @staticmethod
+    def _format_substring_like(value) -> str:
+        return "'%{}%'".format(value)
 
     @staticmethod
     def _escape_value(value, comparator=None) -> str:
@@ -108,35 +112,37 @@ class AqlQueryStringPatternTranslator:
         mapped_fields_count = 1 if is_reference_value else len(mapped_fields_array)
 
         for mapped_field in mapped_fields_array:
+            field_comparator = comparator
+            field_value = value
             # if its a set operator() query construction will be different.
             if expression.object_path in FILTERING_DATA_TYPES.keys():
-                comparison_string += "{}({})".format(FILTERING_DATA_TYPES[expression.object_path], value)
+                comparison_string += "{}({})".format(FILTERING_DATA_TYPES[expression.object_path], field_value)
             elif expression.comparator == ComparisonComparators.IsSubSet:
-                comparison_string += comparator + "(" + "'" + value + "'," + mapped_field + ")"
+                comparison_string += field_comparator + "(" + "'" + field_value + "'," + mapped_field + ")"
             elif is_reference_value:
-                parsed_reference = self._parse_reference(self, stix_field, value_type, mapped_field, value, comparator)
+                parsed_reference = self._parse_reference(self, stix_field, value_type, mapped_field, field_value, field_comparator)
                 if not parsed_reference:
                     continue
                 comparison_string += parsed_reference
             # For [ipv4-addr:value = <CIDR value>]
             elif bool(re.search(observable.REGEX['ipv4_cidr'], str(expression.value))):
-                comparison_string += "INCIDR(" + value + "," + mapped_field + ")"
+                comparison_string += "INCIDR(" + field_value + "," + mapped_field + ")"
             elif (expression.object_path == 'ipv4-addr:value'
                   or expression.object_path == 'ipv6-addr:value'
                   or expression.object_path == 'network-traffic:dst_ref.value'
                   or expression.object_path == 'network-traffic:src_ref.value') \
                   and expression.comparator == ComparisonComparators.Like:
                       comparison_string += "str({mapped_field}) {comparator} {value}".format(mapped_field=mapped_field,
-                                                                                             comparator=comparator,
-                                                                                             value=value)
+                                                                                             comparator=field_comparator,
+                                                                                             value=field_value)
             else:
                 # There's no aql field for domain-name. using Like operator to find domian name from the url
-                if mapped_field == 'domainname' and comparator != ComparisonComparators.Like:
-                    comparator = self.comparator_lookup["ComparisonComparators.Like"]
-                    value = self._format_like(expression.value)
+                if self.dmm.dialect == 'events' and mapped_field == 'dnsdomainname' and expression.comparator != ComparisonComparators.Like:
+                    field_comparator = self.comparator_lookup["ComparisonComparators.Like"]
+                    field_value = AqlQueryStringPatternTranslator._format_substring_like(expression.value)
 
                 comparison_string += "{mapped_field} {comparator} {value}".format(
-                    mapped_field=mapped_field, comparator=comparator, value=value)
+                    mapped_field=mapped_field, comparator=field_comparator, value=field_value)
 
             if (mapped_fields_count > 1):
                 comparison_string += " OR "
@@ -237,7 +243,7 @@ class AqlQueryStringPatternTranslator:
         elif expression.comparator == ComparisonComparators.Equal or expression.comparator == ComparisonComparators.NotEqual:
             # Should be in single-quotes
             value = self._format_equality(expression.value)
-        # '%' -> '*' wildcard, '_' -> '?' single wildcard
+        # Pass STIX LIKE wildcards (% and _) through unchanged
         elif expression.comparator == ComparisonComparators.Like and not (expression.object_path == 'artifact:payload_bin'):
             value = self._format_like(expression.value)
         else:

--- a/stix_shifter_modules/qradar_perf_test/tests/stix_translation/qradar_perf_test_stix_to_aql/test_qradar_perf_test_events_stix_to_query.py
+++ b/stix_shifter_modules/qradar_perf_test/tests/stix_translation/qradar_perf_test_stix_to_aql/test_qradar_perf_test_events_stix_to_query.py
@@ -247,7 +247,7 @@ class TestQueryTranslator(unittest.TestCase, object):
     def test_domainname_query(self):
         stix_pattern = "[domain-name:value = 'example.com']"
         query = _translate_query(stix_pattern)
-        where_statement = "WHERE (dnsdomainname LIKE '%example.com%' OR UrlHost LIKE '%example.com%') {} {}".format(default_limit, default_time)
+        where_statement = "WHERE (dnsdomainname LIKE '%example.com%' OR UrlHost = 'example.com') {} {}".format(default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_generic_filehash_query(self):
@@ -312,7 +312,7 @@ class TestQueryTranslator(unittest.TestCase, object):
         search_string = 'example.com'
         stix_pattern = "[url:value LIKE '{}']".format(search_string)
         query = _translate_query(stix_pattern)
-        where_statement = "WHERE url LIKE '%{0}%' {1} {2}".format(search_string, default_limit, default_time)
+        where_statement = "WHERE url LIKE '{0}' {1} {2}".format(search_string, default_limit, default_time)
         _test_query_assertions(query, selections, from_statement, where_statement)
 
     def test_payload_string_matching_with_LIKE(self):
@@ -371,10 +371,48 @@ class TestQueryTranslator(unittest.TestCase, object):
         stix_pattern = "([ipv4-addr:value = '192.168.1.2'] OR [url:value LIKE '%.example.com']) START t'2020-09-11T13:00:52.000Z' STOP t'2020-09-11T13:59:04.000Z'"
         query = _translate_query(stix_pattern)
         where_statement_01 = "WHERE (sourceip = '192.168.1.2' OR destinationip = '192.168.1.2' OR identityip = '192.168.1.2') limit 10000 START 1599829252000 STOP 1599832744000"
-        where_statement_02 = "WHERE url LIKE '%%.example.com%' limit 10000 START 1599829252000 STOP 1599832744000"
+        where_statement_02 = "WHERE url LIKE '%.example.com' limit 10000 START 1599829252000 STOP 1599832744000"
         assert len(query['queries']) == 2
         assert query['queries'][0] == selections + from_statement + where_statement_01
         assert query['queries'][1] == selections + from_statement + where_statement_02
+
+    def test_LIKE_operator_prefix_wildcard(self):
+        stix_pattern = "[url:value LIKE 'S_on%']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE url LIKE 'S_on%' {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_LIKE_operator_suffix_wildcard(self):
+        stix_pattern = "[url:value LIKE '%.example.com']"
+        query = _translate_query(stix_pattern)
+        where_statement = "WHERE url LIKE '%.example.com' {} {}".format(default_limit, default_time)
+        _test_query_assertions(query, selections, from_statement, where_statement)
+
+    def test_domainname_equality_field_order_independence(self):
+        from stix_shifter_modules.qradar.stix_translation.query_constructor import AqlQueryStringPatternTranslator
+        from stix_shifter_utils.stix_translation.src.patterns.pattern_objects import ComparisonExpression, ComparisonComparators
+
+        class MockSelf:
+            class dmm:
+                dialect = 'events'
+            comparator_lookup = {"ComparisonComparators.Like": "LIKE"}
+
+            @staticmethod
+            def _is_reference_value(stix_field):
+                return AqlQueryStringPatternTranslator._is_reference_value(stix_field)
+
+        expression = ComparisonExpression('domain-name:value', 'example.com', ComparisonComparators.Equal)
+        mock_self = MockSelf()
+        value = "'example.com'"
+        comparator = "="
+
+        result_default = AqlQueryStringPatternTranslator._parse_mapped_fields(
+            mock_self, expression, value, comparator, 'value', ['dnsdomainname', 'UrlHost'])
+        assert result_default == "dnsdomainname LIKE '%example.com%' OR UrlHost = 'example.com'"
+
+        result_reversed = AqlQueryStringPatternTranslator._parse_mapped_fields(
+            mock_self, expression, value, comparator, 'value', ['UrlHost', 'dnsdomainname'])
+        assert result_reversed == "UrlHost = 'example.com' OR dnsdomainname LIKE '%example.com%'"
 
     def test_registry_search(self):
         stix_pattern = "[windows-registry-key:values[*].name = 'abcd']"


### PR DESCRIPTION
Partially addresses #1649 by refining the LIKE operator translation in QRadar module to differentiate between substring search and exact matches, while preserving the preexisting behavior for domain-name equality queries and payload TEXT SEARCH.

STIX LIKE patterns are now passed through unchanged instead of being wrapped with %...%, so user-supplied wildcards keep their intended meaning. Substring matching is retained only for the events domain-name = workaround on dnsdomainname.

Fixes preexisting tests to correctly use the fixed LIKE comparator. 